### PR TITLE
additional explanation on rewrite

### DIFF
--- a/src/plfa/Relations.lagda
+++ b/src/plfa/Relations.lagda
@@ -404,6 +404,8 @@ result and the commutativity of addition.
 \end{code}
 Rewriting by `+-comm m p` and `+-comm n p` converts `m + p ≤ n + p` into
 `p + m ≤ p + n`, which is proved by invoking `+-monoʳ-≤ p m n m≤n`.
+(Go ahead to read a chapter [Equality Rewriting expanded] for details how 
+`rewrite` notation works internally).
 
 Third, we combine the two previous results.
 \begin{code}


### PR DESCRIPTION
"Rewriting by +-comm m p and +-comm n p converts m + p ≤ n + p into p + m ≤ p + n, which is proved by invoking +-monoʳ-≤ p m n m≤n."
The above sentence from the chapter "Relation: Monotonicity" as a conclusion, is not easy to grasp until someone knows how the notation "rewrite" works or has previously been familiar with the material from the chapter "Equality: Rewriting expanded".
In addition, the definition of monotonicity using the notation "with" could serve as an additional exercise, for example:
+-monoˡ-≤1 : ∀ (m n p : ℕ) → m ≤ n → m + p ≤ n + p
+-monoˡ-≤1 m n p mn with    m + p |  +-comm m p  | n + p  |  +-comm n p
...                                      | .(p + m)  | refl | .(p + n) | refl = +-monoʳ-≤ p m n mn
