### PR TITLE
Use new local reference syntax

### DIFF
--- a/src/plfa/Bisimulation.lagda
+++ b/src/plfa/Bisimulation.lagda
@@ -117,14 +117,14 @@ above is a simulation from source to target.  We leave
 establishing it in the reverse direction as an exercise.
 Another exercise is to show the alternative formulations
 of products in
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %})
+Chapter [More][plfa.More]
 are in bisimulation.
     
     
 ## Imports
 
 We import our source language from
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %}).
+Chapter [More][plfa.More].
 \begin{code}
 open import plfa.More
 \end{code}
@@ -162,8 +162,7 @@ data _~_ : ∀ {Γ A} → (Γ ⊢ A) → (Γ ⊢ A) → Set where
       ----------------------
     → `let M N ~ (ƛ N†) · M†
 \end{code}
-The language in Chapter [More]({{ site.baseurl }}{% link
-out/plfa/More.md %}) has more constructs, which we could easily add.
+The language in Chapter [More][plfa.More] has more constructs, which we could easily add.
 However, leaving the simulation small let's us focus on the essence.
 It's a handy technical trick that we can have a large source language,
 but only bother to include in the simulation the terms of interest.
@@ -455,7 +454,7 @@ a bisimulation.
 #### Exercise `products`
 
 Show that the two formulations of products in
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %})
+Chapter [More][plfa.More]
 are in bisimulation.  The only constructs you need to include are
 variables, and those connected to functions and products.
 In this case, the simulation is _not_ lock-step.

--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -838,9 +838,9 @@ The standard library constructs pairs with `_,_` whereas we use `⟨_,_⟩`.
 The former makes it convenient to build triples or larger tuples from pairs,
 permitting `a , b , c` to stand for `(a , (b , c))`.  But it conflicts with
 other useful notations, such as `[_,_]` to construct a list of two elements in
-Chapter [Lists]({{ site.baseurl }}{% link out/plfa/Lists.md %})
+Chapter [Lists][plfa.Lists]
 and `Γ , A` to extend environments in
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}).
+Chapter [DeBruijn][plfa.DeBruijn].
 The standard library `_⇔_` is similar to ours, but the one in the
 standard library is less convenient, since it is parameterised with
 respect to an arbitrary notion of equivalence.

--- a/src/plfa/DeBruijn.lagda
+++ b/src/plfa/DeBruijn.lagda
@@ -54,10 +54,10 @@ And here is its corresponding type derivation:
                ∋z = Z
 
 (These are both taken from Chapter
-[Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %})
+[Lambda][plfa.Lambda]
 and you can see the corresponding derivation tree written out
 in full
-[here]({{ site.baseurl }}{% link out/plfa/Lambda.md %}/#derivation).)
+[here][plfa.Lambda#derivation].)
 The two definitions are in close correspondence, where
 
   * `` `_ `` corresponds to `` ⊢` ``
@@ -110,7 +110,7 @@ typed terms, which in context `Γ` have type `A`.
 While these two choices fit well, they are independent.  One
 can use De Bruijn indices in raw terms, or (with more
 difficulty) have inherently typed terms with names.  In
-Chapter [Untyped]({{ site.baseurl }}{% link out/plfa/Untyped.md %},
+Chapter [Untyped][plfa.Untyped],
 we will introduce terms with De Bruijn indices that
 are inherently scoped but not typed.
 
@@ -407,7 +407,7 @@ lookup ∅       _        =  ⊥-elim impossible
 We intend to apply the function only when the natural is
 shorter than the length of the context, which we indicate by
 postulating an `impossible` term, just as we did
-[here]({{ site.baseurl }}{% link out/plfa/Lambda.md %}/#impossible).
+[here][plfa.Lambda#impossible].
 
 Given the above, we can convert a natural to a corresponding
 De Bruijn index, looking up its type in the context.
@@ -436,9 +436,9 @@ _ = ƛ ƛ (# 1 · (# 1 · # 0))
 ### Test examples
 
 We repeat the test examples from
-Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %}).
+Chapter [Lambda][plfa.Lambda].
 You can find the 
-[here]({{ site.baseurl }}{% link out/plfa/Lambda.md %}/#derivation)
+[here][plfa.Lambda#derivation]
 for comparison.
 
 First, computing two plus two on naturals.
@@ -766,7 +766,7 @@ data Value : ∀ {Γ A} → Γ ⊢ A → Set where
 
 Here `zero` requires an implicit parameter to aid inference,
 much in the same way that `[]` did in
-[Lists]({{ site.baseurl }}{% link out/plfa/Lists.md %})).
+[Lists][plfa.Lists].
 
 
 ## Reduction

--- a/src/plfa/Decidable.lagda
+++ b/src/plfa/Decidable.lagda
@@ -36,7 +36,7 @@ open import plfa.Connectives using (_⇔_)
 
 ## Evidence vs Computation
 
-Recall that Chapter [Relations]({{ site.baseurl }}{% link out/plfa/Relations.md %})
+Recall that Chapter [Relations][plfa.Relations]
 defined comparison an inductive datatype, which provides _evidence_ that one number
 is less than or equal to another.
 \begin{code}
@@ -536,7 +536,7 @@ postulate
 #### Exercise `_iff_ `, `_⇔-dec_`
 
 Give analogues of the `_⇔_` operation from 
-Chapter [Connectives]({{ site.baseurl }}{% link out/plfa/Connectives.md %}#iff),
+Chapter [Connectives][plfa.Connectives#iff],
 operation on booleans and decidables, and also show the corresponding erasure.
 \begin{code}
 postulate

--- a/src/plfa/Equality.lagda
+++ b/src/plfa/Equality.lagda
@@ -348,7 +348,7 @@ an order that will make sense to the reader.
 #### Exercise `≤-reasoning` (stretch)
 
 The proof of monotonicity from
-Chapter [Relations]({{ site.baseurl }}{% link out/plfa/Relations.md %})
+Chapter [Relations][plfa.Relations]
 can be written in a more readable form by using an anologue of our
 notation for `≡-reasoning`.  Define `≤-reasoning` analogously, and use
 it to write out an alternative proof that addition is monotonic with

--- a/src/plfa/Induction.lagda
+++ b/src/plfa/Induction.lagda
@@ -584,7 +584,7 @@ which is left as an exercise for the reader.
 
 Write out what is known about associativity of addition on each of the first four
 days using a finite story of creation, as
-[earlier]({{ site.baseurl }}{% link out/plfa/Naturals.md %}#finite-creation).
+[earlier][plfa.Naturals#finite-creation]
 
 
 ## Associativity with rewrite
@@ -796,7 +796,7 @@ for all naturals `m`, `n`, and `p`.
 #### Exercise `Bin-laws` (stretch) {#Bin-laws}
 
 Recall that 
-Exercise [Bin]({{ site.baseurl }}{% link out/plfa/Naturals.md %}#Bin)
+Exercise [Bin][plfa.Naturals#Bin]
 defines a datatype of bitstrings representing natural numbers
 \begin{code}
 data Bin : Set where

--- a/src/plfa/Inference.lagda
+++ b/src/plfa/Inference.lagda
@@ -938,7 +938,7 @@ _ : synthesize ∅ ((two ↓ `ℕ) · two) ≡ no _
 _ = refl
 \end{code}
 
-Abstraction inherits type natural.p
+Abstraction inherits type natural.
 \begin{code}
 _ : synthesize ∅ (twoᶜ ↓ `ℕ) ≡ no _
 _ = refl

--- a/src/plfa/Inference.lagda
+++ b/src/plfa/Inference.lagda
@@ -10,9 +10,9 @@ module plfa.Inference where
 
 So far in our development, type derivations for the corresponding
 term have been provided by fiat.  
-In Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %})
+In Chapter [Lambda][plfa.Lambda]
 type derivations were given separately from the term, while
-in Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %})
+in Chapter [DeBruijn][plfa.DeBruijn]
 the type derivation was inherently part of the term.
 
 In practice, one often writes down a term with a few decorations and
@@ -25,9 +25,9 @@ inference, which will be presented in this chapter.
 
 This chapter ties our previous developements together. We begin with
 a term with some type annotations, quite close to the raw terms of
-Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %}),
+Chapter [Lambda][plfa.Lambda],
 and from it we compute a term with inherent types, in the style of
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}).
+Chapter [DeBruijn][plfa.DeBruijn].
 
 ## Introduction: Inference rules as algorithms {#algorithms}
 
@@ -304,7 +304,7 @@ Id = String
 \end{code}
 
 And so are contexts. (Recall that `Type` is imported from
-[DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}).)
+[DeBruijn][plfa.DeBruijn].)
 \begin{code}
 data Context : Set where
   ∅     : Context
@@ -384,7 +384,7 @@ required for `sucᶜ`, which inherits its type as an argument of `plusᶜ`.
 ## Bidirectional type checking
 
 The typing rules for variables are as in
-[Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %}).
+[Lambda][plfa.Lambda].
 \begin{code}
 data _∋_⦂_ : Context → Id → Type → Set where
 
@@ -458,31 +458,31 @@ data _⊢_↓_ where
     → Γ ⊢ (M ↑) ↓ B
 \end{code}
 We follow the same convention as
-Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %}),
+Chapter [Lambda][plfa.Lambda],
 prefacing the constructor with `⊢` to derive the name of the
 corresponding type rule.
 
 The rules are similar to those in
-Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %}),
+Chapter [Lambda][plfa.Lambda],
 modified to support synthesised and inherited types.
 The two new rules are those for `⊢↑` and `⊢↓`.
 The former both passes the type decoration as the inherited type and returns
 it as the synthesised type.  The latter takes the synthesised type and the
 inherited type and confirms they are identical --- it should remind you of
 the equality test in the application rule in the first
-[section]({{ site.baseurl }}{% link out/plfa/Inference.md %}/#algorithms).
+[section][plfa.Inference#algorithms].
 
 
 #### Exercise `bidirectional-ps`
 
 Extend the bidirectional type rules to include products and sums from
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %}).
+Chapter [More][plfa.More].
 
 
 #### Exercise `bidirectional-rest` (stretch)
 
 Extend the bidirectional type rules to include the rest of the constructs from
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %}).
+Chapter [More][plfa.More].
 
 
 ## Prerequisites
@@ -938,7 +938,7 @@ _ : synthesize ∅ ((two ↓ `ℕ) · two) ≡ no _
 _ = refl
 \end{code}
 
-Abstraction inherits type natural.
+Abstraction inherits type natural.p
 \begin{code}
 _ : synthesize ∅ (twoᶜ ↓ `ℕ) ≡ no _
 _ = refl
@@ -988,7 +988,7 @@ _ = refl
 From the evidence that a decorated term has the correct type it is
 easy to extract the corresponding inherently typed term.  We use the
 name `DB` to refer to the code in
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}).
+Chapter [DeBruijn][plfa.DeBruijn].
 It is easy to define an _erasure_ function that takes evidence of a
 type judgement into the corresponding inherently typed term.
 
@@ -1043,21 +1043,21 @@ _ = refl
 \end{code}
 Thus, we have confirmed that bidirectional type inference
 converts decorated versions of the lambda terms from
-Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %})
+Chapter [Lambda][plfa.Lambda]
 to the inherently typed terms of
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}).
+Chapter [DeBruijn][plfa.DeBruijn].
 
 
 #### Exercise `inference-p`
 
 Extend bidirectional inference to include products from
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %}).
+Chapter [More][plfa.More].
 
 
 #### Exercise `inference-rest` (stretch)
 
 Extend the bidirectional type rules to include the rest of the constructs from
-Chapter [More]({{ site.baseurl }}{% link out/plfa/More.md %}).
+Chapter [More][plfa.More].
 
 
 ## Bidirectional inference in Agda

--- a/src/plfa/Isomorphism.lagda
+++ b/src/plfa/Isomorphism.lagda
@@ -89,7 +89,7 @@ Extensionality asserts that the only way to distinguish functions is
 by applying them; if two functions applied to the same argument always
 yield the same result, then they are the same function.  It is the
 converse of `cong-app`, as introduced
-[earlier]({{ site.baseurl }}{% link out/plfa/Equality.md %}/#cong).
+[earlier][plfa.Equality#cong].
 
 Agda does not presume extensionality, but we can postulate that it holds.
 \begin{code}
@@ -104,7 +104,7 @@ known to be consistent with the theory that underlies Agda.
 
 As an example, consider that we need results from two libraries,
 one where addition is defined, as in
-Chapter [Naturals]({{ site.baseurl }}{% link out/plfa/Naturals.md %}),
+Chapter [Naturals][plfa.Naturals],
 and one where it is defined the other way around.
 \begin{code}
 _+′_ : ℕ → ℕ → ℕ
@@ -436,8 +436,8 @@ postulate
 #### Exercise `Bin-embedding` (stretch) {#Bin-embedding}
 
 Recall that Exercises
-[Bin]({{ site.baseurl }}{% link out/plfa/Naturals.md %}#Bin) and
-[Bin-laws]({{ site.baseurl }}{% link out/plfa/Induction.md %}#Bin-laws)
+[Bin][plfa.Naturals#Bin] and
+[Bin-laws][plfa.Induction#Bin-laws]
 define a datatype of bitstrings representing natural numbers.
 \begin{code}
 data Bin : Set where

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -23,7 +23,7 @@ recursive function definitions.
 
 This chapter formalises the simply-typed lambda calculus, giving its
 syntax, small-step semantics, and typing rules.  The next chapter
-[Properties]({{ site.baseurl }}{% link out/plfa/Properties.md %})
+[Properties][plfa.Properties]
 proves its main properties, including
 progress and preservation.  Following chapters will look at a number
 of variants of lambda calculus.
@@ -31,7 +31,7 @@ of variants of lambda calculus.
 Be aware that the approach we take here is _not_ our recommended
 approach to formalisation.  Using De Bruijn indices and
 inherently-typed terms, as we will do in
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}),
+Chapter [DeBruijn][plfa.DeBruijn],
 leads to a more compact formulation.  Nonetheless, we begin with named
 variables, partly because such terms are easier to read and partly
 because the development is more traditional.
@@ -139,7 +139,7 @@ plus = μ "+" ⇒ ƛ "m" ⇒ ƛ "n" ⇒
 \end{code}
 The recursive definition of addition is similar to our original
 definition of `_+_` for naturals, as given in
-Chapter [Naturals]({{ site.baseurl }}{% link out/plfa/Naturals.md %}#plus).
+Chapter [Naturals][plfa.Naturals#plus].
 Here variable "m" is bound twice, once in a lambda abstraction and once in
 the successor branch of the case; the first use of "m" refers to
 the former and the second to the latter.  Any use of "m" in the successor branch
@@ -359,7 +359,7 @@ to treat variables as values, and to treat
 `ƛ x ⇒ N` as a value only if `N` is a value.
 Indeed, this is how Agda normalises terms.
 We consider this approach in
-Chapter [Untyped]({{ site.baseurl }}{% link out/plfa/Untyped.md %}).
+Chapter [Untyped][plfa.Untyped].
 
 
 ## Substitution
@@ -644,7 +644,7 @@ the reflexive and transitive closure `—↠` of the step relation `—→`.
 We define reflexive and transitive closure as a sequence of zero or
 more steps of the underlying relation, along lines similar to that for
 reasoning about chains of equalities
-Chapter [Equality]({{ site.baseurl }}{% link out/plfa/Equality.md %}).
+Chapter [Equality][plfa.Equality].
 \begin{code}
 infix  2 _—↠_
 infix  1 begin_
@@ -1250,7 +1250,7 @@ We can fill in `Z` by hand. If we type C-c C-space, Agda will confirm we are don
 
 The entire process can be automated using Agsy, invoked with C-c C-a.
 
-Chapter [Inference]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %})
+Chapter [Inference][plfa.DeBruijn]
 will show how to use Agda to compute type derivations directly.
 
 

--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -892,7 +892,7 @@ replacement for `_×_`.  As a consequence, demonstrate an isomorphism relating
 #### Exercise `¬Any≃All¬` (stretch)
 
 First generalise composition to arbitrary levels, using
-[universe polymorphism][plfa.Equality#unipoly]
+[universe polymorphism][plfa.Equality#unipoly].
 \begin{code}
 _∘′_ : ∀ {ℓ₁ ℓ₂ ℓ₃ : Level} {A : Set ℓ₁} {B : Set ℓ₂} {C : Set ℓ₃}
   → (B → C) → (A → B) → A → C

--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -892,14 +892,12 @@ replacement for `_×_`.  As a consequence, demonstrate an isomorphism relating
 #### Exercise `¬Any≃All¬` (stretch)
 
 First generalise composition to arbitrary levels, using
-[universe polymorphism][unipoly].
+[universe polymorphism][plfa.Equality#unipoly]
 \begin{code}
 _∘′_ : ∀ {ℓ₁ ℓ₂ ℓ₃ : Level} {A : Set ℓ₁} {B : Set ℓ₂} {C : Set ℓ₃}
   → (B → C) → (A → B) → A → C
 (g ∘′ f) x  =  g (f x)
 \end{code}
-
-[unipoly]: {{ site.baseurl }}{% link out/plfa/Equality.md %}#unipoly
 
 Show that `Any` and `All` satisfy a version of De Morgan's Law.
 \begin{code}

--- a/src/plfa/More.lagda
+++ b/src/plfa/More.lagda
@@ -29,10 +29,10 @@ informal. We show how to formalise the first four constructs and leave
 the rest as an exercise for the reader.
 
 Our informal descriptions will be in the style of
-Chapter [Lambda]({{ site.baseurl }}{% link out/plfa/Lambda.md %}),
+Chapter [Lambda][plfa.Lambda],
 using named variables and a separate type relation,
 while our formalisation will be in the style of
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}),
+Chapter [DeBruijn][plfa.DeBruijn],
 using de Bruijn indices and inherently typed terms.
 
 By now, explaining with symbols should be more concise, more precise,

--- a/src/plfa/Naturals.lagda
+++ b/src/plfa/Naturals.lagda
@@ -271,7 +271,7 @@ all the names specified in the `using` clause into the current scope.
 In this case, the names added are `begin_`, `_≡⟨⟩_`, and `_∎`.  We
 will see how these are used below.  We take these as givens for now,
 but will see how they are defined in
-Chapter [Equality]({{ site.baseurl }}{% link out/plfa/Equality.md %}).
+Chapter [Equality][plfa.Equality].
 
 Agda uses underbars to indicate where terms appear in infix or mixfix
 operators. Thus, `_≡_` and `_≡⟨⟩_` are infix (each operator is written

--- a/src/plfa/Negation.lagda
+++ b/src/plfa/Negation.lagda
@@ -161,14 +161,14 @@ the other.
 #### Exercise `<-irreflexive`
 
 Using negation, show that
-[strict inequality]({{ site.baseurl }}{% link out/plfa/Relations.md %}/#strict-inequality)
+[strict inequality][plfa.Relations#strict-inequality]
 is irreflexive, that is, `n < n` holds for no `n`.
 
 
 #### Exercise `trichotomy`
 
 Show that strict inequality satisfies
-[trichotomy]({{ site.baseurl }}{% link out/plfa/Relations.md %}/#trichotomy),
+[trichotomy][plfa.Relations#trichotomy],
 that is, for any naturals `m` and `n` exactly one of the following holds:
 
 * `m < n`

--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -93,7 +93,7 @@ postulate
     (∀ (x : A) → B x × C x) ≃ (∀ (x : A) → B x) × (∀ (x : A) → C x)
 \end{code}
 Compare this with the result (`→-distrib-×`) in
-Chapter [Connectives]({{ site.baseurl }}{% link out/plfa/Connectives.md %}).
+Chapter [Connectives][plfa.Connectives].
 
 #### Exercise `⊎∀-implies-∀⊎`
 
@@ -222,9 +222,7 @@ Indeed, the converse also holds, and the two together form an isomorphism.
 \end{code}
 The result can be viewed as a generalisation of currying.  Indeed, the code to
 establish the isomorphism is identical to what we wrote when discussing
-[implication][implication].
-
-[implication]: {{ site.baseurl }}{% link out/plfa/Connectives.md %}/#implication
+[implication][plfa.Connectives#implication].
 
 #### Exercise `∃-distrib-⊎`
 
@@ -249,7 +247,7 @@ Does the converse hold? If so, prove; if not, explain why.
 ## An existential example
 
 Recall the definitions of `even` and `odd` from
-Chapter [Relations]({{ site.baseurl }}{% link out/plfa/Relations.md %}).
+Chapter [Relations][plfa.Relations].
 \begin{code}
 data even : ℕ → Set
 data odd  : ℕ → Set
@@ -410,9 +408,9 @@ Does the converse hold? If so, prove; if not, explain why.
 #### Exercise `Bin-isomorphism` (stretch) {#Bin-isomorphism}
 
 Recall that Exercises
-[Bin]({{ site.baseurl }}{% link out/plfa/Naturals.md %}#Bin),
-[Bin-laws]({{ site.baseurl }}{% link out/plfa/Induction.md %}#Bin-laws), and
-[Bin-predicates]({{ site.baseurl }}{% link out/plfa/Relations.md %}#Bin-predicates)
+[Bin][plfa.Naturals#Bin],
+[Bin-laws][plfa.Induction#Bin-laws], and
+[Bin-predicates][plfa.Relations#Bin-predicates]
 define a datatype of bitstrings representing natural numbers.
 \begin{code}
 data Bin : Set where

--- a/src/plfa/Relations.lagda
+++ b/src/plfa/Relations.lagda
@@ -157,7 +157,7 @@ either `(1 ≤ 2) ≤ 3` or `1 ≤ (2 ≤ 3)`.
 Given two numbers, it is straightforward to compute whether or not the
 first is less than or equal to the second.  We don't give the code for
 doing so here, but will return to this point in
-Chapter [Decidable]({{ site.baseurl }}{% link out/plfa/Decidable.md %}).
+Chapter [Decidable][plfa.Decidable].
 
 
 ## Properties of ordering relations
@@ -524,7 +524,7 @@ It is also monotonic with regards to addition and multiplication.
 Most of the above are considered in exercises below.  Irreflexivity
 requires negation, as does the fact that the three cases in
 trichotomy are mutually exclusive, so those points are deferred to
-Chapter [Negation]({{ site.baseurl }}{% link out/plfa/Negation.md %}).
+Chapter [Negation][plfa.Negation].
 
 It is straightforward to show that `suc m ≤ n` implies `m < n`,
 and conversely.  One can then give an alternative derivation of the
@@ -546,7 +546,7 @@ Define `m > n` to be the same as `n < m`.
 You will need a suitable data declaration,
 similar to that used for totality.
 (We will show that the three cases are exclusive after we introduce
-[negation]({{ site.baseurl }}{% link out/plfa/Negation.md %}).)
+[negation][plfa.Negation].)
 
 #### Exercise `+-mono-<` {#plus-mono-less}
 
@@ -669,7 +669,7 @@ Show that the sum of two odd numbers is even.
 #### Exercise `Bin-predicates` (stretch) {#Bin-predicates}
 
 Recall that 
-Exercise [Bin]({{ site.baseurl }}{% link out/plfa/Naturals.md %}#Bin)
+Exercise [Bin][plfa.Naturals#Bin]
 defines a datatype of bitstrings representing natural numbers.
 \begin{code}
 data Bin : Set where
@@ -731,7 +731,7 @@ import Data.Nat.Properties using (≤-refl; ≤-trans; ≤-antisym; ≤-total;
 \end{code}
 In the standard library, `≤-total` is formalised in terms of
 disjunction (which we define in
-Chapter [Connectives]({{ site.baseurl }}{% link out/plfa/Connectives.md %})),
+Chapter [Connectives][plfa.Connectives]),
 and `+-monoʳ-≤`, `+-monoˡ-≤`, `+-mono-≤` are proved differently than here,
 and more arguments are implicit.
 

--- a/src/plfa/SystemF.lagda
+++ b/src/plfa/SystemF.lagda
@@ -254,7 +254,7 @@ data _⊢_ : ∀ {J} (Γ : Ctx) → ∥ Γ ∥ ⊢⋆ J → Set where
 ## Remainder
 
 The development continues from here as in
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}),
+Chapter [DeBruijn][plfa.DeBruijn],
 defining renaming and substitution on terms and introducing reduction
 rules for terms, proving progress, and applying progress to derive an
 evaluator.

--- a/src/plfa/Untyped.lagda
+++ b/src/plfa/Untyped.lagda
@@ -59,7 +59,7 @@ open import Relation.Nullary.Product using (_×-dec_)
 ## Untyped is Uni-typed
 
 Our development will be close to that in
-Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}),
+Chapter [DeBruijn][plfa.DeBruijn],
 save that every term will have exactly the same type, written `★`
 and pronounced "any".
 This matches a slogan introduced by Dana Scott
@@ -726,7 +726,7 @@ the same term.
 #### Exercise `encode-more` (stretch)
 
 Along the lines above, encode all of the constructs of
-Chapter [More]({{ site.baseurl }}{% link out/plfa/Lambda.md %}),
+Chapter [More][plfa.More],
 save for primitive numbers, in the untyped lambda calculus.
 
 


### PR DESCRIPTION
Book builds and links work (including #sections). 

I assume that the link named More on line 729 of Untyped.lagda is intended to point to plfa.More, not plfa.Lambda, and have fixed this.