### PR TITLE
Remove answer from recommended exercise

### DIFF
--- a/tspl/Assignment2.lagda
+++ b/tspl/Assignment2.lagda
@@ -123,17 +123,6 @@ Why is there not an isomorphism?
 Show that `A ⇔ B` as defined [earlier][plfa.Isomorphism#iff]
 is isomorphic to `(A → B) × (B → A)`.
 
-\begin{code}
-⇔≃× : ∀ {A B : Set} → (A ⇔ B) ≃ (A → B) × (B → A)
-⇔≃× =
-  record
-    { to  =  λ{ A⇔B → ⟨ to A⇔B , from A⇔B ⟩ }
-    ; from  =  λ{ ⟨ A→B , B→A ⟩ → record { to = A→B ; from = B→A } }
-    ; from∘to = λ{ A⇔B → refl }  
-    ; to∘from =  λ{ ⟨ A→B , B→A ⟩ → refl }
-    }
-\end{code}
-
 #### Exercise `⊎-comm` (recommended)
 
 Show sum is commutative up to isomorphism.


### PR DESCRIPTION
It seems like someone added the answer by accident. I noticed it when I pulled the latest and got a conflict.