### PR TITLE
Fix typo

### DIFF
--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -1364,7 +1364,7 @@ postulate
     → ∅ ⊢ M ⦂ A
     → M —↠ N
       -----------
-    → ¬ (Stuck M)
+    → ¬ (Stuck N)
 \end{code}
 Felleisen and Wright, who introduced proofs via progress and
 preservation, summarised this result with the slogan _well-typed terms


### PR DESCRIPTION
If we would try to prove `\neg (Stuck M)` then there would could trivially use the result from `unstuck`