### PR TITLE
Part I: Minor fixes

### DIFF
--- a/src/plfa/Decidable.lagda
+++ b/src/plfa/Decidable.lagda
@@ -357,11 +357,11 @@ m ≤ᵇ′ n  =  ⌊ m ≤? n ⌋
 Further, if `D` is a value of type `Dec A`, then `T ⌊ D ⌋` is
 inhabited exactly when `A` is inhabited.
 \begin{code}
-toWitness : ∀ {A : Set} → {D : Dec A} → T ⌊ D ⌋ → A
+toWitness : ∀ {A : Set} {D : Dec A} → T ⌊ D ⌋ → A
 toWitness {A} {yes x} tt  =  x
 toWitness {A} {no ¬x} ()
 
-fromWitness : ∀ {A : Set} → {D : Dec A} → A → T ⌊ D ⌋
+fromWitness : ∀ {A : Set} {D : Dec A} → A → T ⌊ D ⌋
 fromWitness {A} {yes x} _  =  tt
 fromWitness {A} {no ¬x} x  =  ¬x x
 \end{code}
@@ -405,7 +405,7 @@ decide their conjunction.
 \begin{code}
 infixr 6 _×-dec_
 
-_×-dec_ : {A B : Set} → Dec A → Dec B → Dec (A × B)
+_×-dec_ : ∀ {A B : Set} → Dec A → Dec B → Dec (A × B)
 yes x ×-dec yes y = yes ⟨ x , y ⟩
 no ¬x ×-dec _     = no λ{ ⟨ x , y ⟩ → ¬x x }
 _     ×-dec no ¬y = no λ{ ⟨ x , y ⟩ → ¬y y }
@@ -442,7 +442,7 @@ decide their disjunction.
 \begin{code}
 infixr 5 _⊎-dec_
 
-_⊎-dec_ : {A B : Set} → Dec A → Dec B → Dec (A ⊎ B)
+_⊎-dec_ : ∀ {A B : Set} → Dec A → Dec B → Dec (A ⊎ B)
 yes x ⊎-dec _     = yes (inj₁ x)
 _     ⊎-dec yes y = yes (inj₂ y)
 no ¬x ⊎-dec no ¬y = no λ{ (inj₁ x) → ¬x x ; (inj₂ y) → ¬y y }
@@ -469,7 +469,7 @@ not false = true
 Correspondingly, given a decidable proposition, we
 can decide its negation.
 \begin{code}
-¬? : {A : Set} → Dec A → Dec (¬ A)
+¬? : ∀ {A : Set} → Dec A → Dec (¬ A)
 ¬? (yes x)  =  no (¬¬-intro x)
 ¬? (no ¬x)  =  yes ¬x
 \end{code}
@@ -499,7 +499,7 @@ the answer is the same.
 Correspondingly, given two decidable propositions,
 we can decide if the first implies the second.
 \begin{code}
-_→-dec_ : {A B : Set} → Dec A → Dec B → Dec (A → B)
+_→-dec_ : ∀ {A B : Set} → Dec A → Dec B → Dec (A → B)
 _     →-dec yes y  =  yes (λ _ → y)
 no ¬x →-dec _      =  yes (λ x → ⊥-elim (¬x x))
 yes x →-dec no ¬y  =  no (λ f → ¬y (f x))

--- a/src/plfa/Equality.lagda
+++ b/src/plfa/Equality.lagda
@@ -19,8 +19,8 @@ here we show how to define it as an inductive datatype.
 ## Imports
 
 This chapter has no imports.  Every chapter in this book, and nearly
-every module in the Agda, imports equality.  Since we define equality
-here, any import would create a conflict.
+every module in the Agda standard library, imports equality.
+Since we define equality here, any import would create a conflict.
 
 
 ## Equality
@@ -485,13 +485,13 @@ justifies that assertion with evidence of the appropriate equality.
 Note also the use of the _dot pattern_, `.(n + m)`.  A dot pattern
 consists of a dot followed by an expression, and is used when other
 information forces the value matched to be equal to the value of the
-expression in the dot pattern.  In this case, the identification of `m
-+ n` and `n + m` is justified by the subsequent matching of `+-comm m
-n` against `refl`.  One might think that the first clause is redundant
-as the information is inherent in the second clause, but in fact Agda
-is rather picky on this point: omitting the first clause or reversing
-the order of the clauses will cause Agda to report an error.  (Try it
-and see!)
+expression in the dot pattern.  In this case, the identification of
+`m + n` and `n + m` is justified by the subsequent matching of
+`+-comm m n` against `refl`.  One might think that the first clause is
+redundant as the information is inherent in the second clause, but in
+fact Agda is rather picky on this point: omitting the first clause or
+reversing the order of the clauses will cause Agda to report an error.
+(Try it and see!)
 
 In this case, we can avoid rewrite by simply applying the substitution
 function defined earlier.
@@ -596,7 +596,7 @@ of `P x` is also a proof of `P y`.
 This direction follows from substitution, which we showed earlier.
 
 In the reverse direction, given that for any `P` we can take a proof of `P x`
-to a proof of `P y` we need to show `x ≡ y`. 
+to a proof of `P y` we need to show `x ≡ y`.
 \begin{code}
 ≐-implies-≡ : ∀ {A : Set} {x y : A}
   → x ≐ y
@@ -706,12 +706,13 @@ collisions, as mentioned in the introduction.
 
 This chapter uses the following unicode.
 
-    ≡  U+2261  IDENTICAL TO (\==)
+    ≡  U+2261  IDENTICAL TO (\==, \equiv)
     ⟨  U+27E8  MATHEMATICAL LEFT ANGLE BRACKET (\<)
     ⟩  U+27E9  MATHEMATICAL RIGHT ANGLE BRACKET (\>)
     ∎  U+220E  END OF PROOF (\qed)
     ≐  U+2250  APPROACHES THE LIMIT (\.=)
     ℓ  U+2113  SCRIPT SMALL L (\ell)
+    ⊔  U+2294  SQUARE CUP (\lub)
     ₀  U+2080  SUBSCRIPT ZERO (\_0)
     ₁  U+2081  SUBSCRIPT ONE (\_1)
     ₂  U+2082  SUBSCRIPT TWO (\_2)

--- a/src/plfa/Induction.lagda
+++ b/src/plfa/Induction.lagda
@@ -874,7 +874,7 @@ import Data.Nat.Properties using (+-assoc; +-identityʳ; +-suc; +-comm)
 
 This chapter uses the following unicode.
 
-    ∀  U+2200  FOR ALL (\forall)
+    ∀  U+2200  FOR ALL (\forall, \all)
     ʳ  U+02B3  MODIFIER LETTER SMALL R (\^r)
     ′  U+2032  PRIME (\')
     ″  U+2033  DOUBLE PRIME (\')

--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -20,7 +20,7 @@ examples of polymorphic types and higher-order functions.
 import Relation.Binary.PropositionalEquality as Eq
 open Eq using (_≡_; refl; sym; trans; cong)
 open Eq.≡-Reasoning
-open import Data.Bool.Base using (Bool; true; false; T; _∧_; _∨_; not)
+open import Data.Bool using (Bool; true; false; T; _∧_; _∨_; not)
 open import Data.Nat using (ℕ; zero; suc; _+_; _*_; _∸_; _≤_; s≤s; z≤n)
 open import Data.Nat.Properties using
   (+-assoc; +-identityˡ; +-identityʳ; *-assoc; *-identityˡ; *-identityʳ)
@@ -551,7 +551,7 @@ data Tree (A B : Set) : Set where
   leaf : A → Tree A B
   node : Tree A B → B → Tree A B → Tree A B
 \end{code}
-Define a suitabve map operator over trees.
+Define a suitable map operator over trees.
 \begin{code}
 postulate
   map-Tree : ∀ {A B C D : Set}
@@ -790,8 +790,8 @@ are `All` and `Any`.
 Predicate `All P` holds if predicate `P` is satisfied by every element of a list.
 \begin{code}
 data All {A : Set} (P : A → Set) : List A → Set where
-  [] : All P []
-  _∷_ : {x : A} {xs : List A} → P x → All P xs → All P (x ∷ xs)
+  []  : All P []
+  _∷_ : ∀ {x : A} {xs : List A} → P x → All P xs → All P (x ∷ xs)
 \end{code}
 The type has two constructors, reusing the names of the same constructors for lists.
 The first asserts that `P` holds for every element of the empty list.
@@ -806,7 +806,7 @@ than or equal to two.  Recall that `z≤n` proves `zero ≤ n` for any
 suc n`, for any `m` and `n`.
 \begin{code}
 _ : All (_≤ 2) [ 0 , 1 , 2 ]
-_ = z≤n ∷ (s≤s z≤n) ∷ (s≤s (s≤s z≤n)) ∷ []
+_ = z≤n ∷ s≤s z≤n ∷ s≤s (s≤s z≤n) ∷ []
 \end{code}
 Here `_∷_` and `[]` are the constructors of `All P` rather than of `List A`.
 The three items are proofs of `0 ≤ 2`, `1 ≤ 2`, and `2 ≤ 2`, respectively.
@@ -823,15 +823,15 @@ scope when the pattern is declared.  That's not the case here, since
 Predicate `Any P` holds if predicate `P` is satisfied by some element of a list.
 \begin{code}
 data Any {A : Set} (P : A → Set) : List A → Set where
-  here :  {x : A} {xs : List A} → P x → Any P (x ∷ xs)
-  there : {x : A} {xs : List A} → Any P xs → Any P (x ∷ xs)
+  here  : ∀ {x : A} {xs : List A} → P x → Any P (x ∷ xs)
+  there : ∀ {x : A} {xs : List A} → Any P xs → Any P (x ∷ xs)
 \end{code}
 The first constructor provides evidence that the head of the list
 satisfies `P`, while the second provides evidence that some element of
 the tail of the list satisfies `P`.  For example, we can define list
 membership as follows.
 \begin{code}
-infix 4 _∈_
+infix 4 _∈_ _∉_
 
 _∈_ : ∀ {A : Set} (x : A) (xs : List A) → Set
 x ∈ xs = Any (x ≡_) xs
@@ -1011,6 +1011,6 @@ ranges over a binary relation).
 This chapter uses the following unicode.
 
     ∷  U+2237  PROPORTION  (\::)
-    ⊗  U+2297  CIRCLED TIMES  (\otimes)
+    ⊗  U+2297  CIRCLED TIMES  (\otimes, \ox)
     ∈  U+2208  ELEMENT OF  (\in)
-    ∉  U+2209  NOT AN ELEMENT OF  (\inn)
+    ∉  U+2209  NOT AN ELEMENT OF  (\inn, \notin)

--- a/src/plfa/Naturals.lagda
+++ b/src/plfa/Naturals.lagda
@@ -922,7 +922,7 @@ Information on pragmas can be found in the Agda documentation.
 This chapter uses the following unicode.
 
     ℕ  U+2115  DOUBLE-STRUCK CAPITAL N (\bN)
-    →  U+2192  RIGHTWARDS ARROW (\to, \r)
+    →  U+2192  RIGHTWARDS ARROW (\to, \r, \->)
     ∸  U+2238  DOT MINUS (\.-)
     ≡  U+2261  IDENTICAL TO (\==)
     ⟨  U+27E8  MATHEMATICAL LEFT ANGLE BRACKET (\<)

--- a/src/plfa/Negation.lagda
+++ b/src/plfa/Negation.lagda
@@ -393,3 +393,4 @@ import Relation.Nullary.Negation using (contraposition)
 This chapter uses the following unicode.
 
     ¬  U+00AC  NOT SIGN (\neg)
+    ≢  U+2262  NOT IDENTICAL TO (\==n)

--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -360,7 +360,7 @@ Show that `y ≤ z` holds if and only if there exists a `x` such that
 
 ## Existentials, Universals, and Negation
 
-Negation of an existential is isomorphic to universal
+Negation of an existential is isomorphic to the universal
 of a negation.  Considering that existentials are generalised
 disjunction and universals are generalised conjunction, this
 result is analogous to the one which tells us that negation


### PR DESCRIPTION
Some minor things I found while reading through the first part.

 * Typos
   - e.g. `suitabve` ~> `suitable`

 * Phrasing
   - e.g. `to universal of` ~> `to the universal of`

 * Simpler imports
   - e.g. `Data.Bool.Base` ~> `Data.Bool`

 * Formatting
   - e.g align clauses, unnecessary parentheses

 * Forgotten unicode symbols
   - e.g. `⊔` in `Equality.lagda`

 * Alternative unicode commands
   - e.g. `\ox` in addition to `\otimes`