### PR TITLE
Fix "arbitary" integers typo

### DIFF
--- a/src/plfa/Naturals.lagda
+++ b/src/plfa/Naturals.lagda
@@ -244,7 +244,7 @@ As well as enabling the above shorthand, the pragma also enables a
 more efficient internal representation of naturals using the Haskell
 type for arbitrary-precision integers.  Representing the natural _n_
 with `zero` and `suc` requires space proportional to _n_, whereas
-representing it as an arbitary-precision integer in Haskell only
+representing it as an arbitrary-precision integer in Haskell only
 requires space proportional to the logarithm of _n_.
 
 


### PR DESCRIPTION
Originally i wanted to point out that arbitrary-precision integers might be not the most precise term, because precision is often associated with reals, but apparently that's an established term. Then i noticed the integers are arbitary in one place ;)