### PR TITLE
Don't conflate "term" with "value"

### DIFF
--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -252,7 +252,7 @@ can conclude.  Since truth always holds, knowing that it holds tells
 us nothing new.
 
 The nullary case of `η-×` is `η-⊤`, which asserts that any
-term of type `⊤` must be equal to `tt`.
+value of type `⊤` must be equal to `tt`.
 \begin{code}
 η-⊤ : ∀ (w : ⊤) → tt ≡ w
 η-⊤ tt = refl


### PR DESCRIPTION
In my understanding, there are many distinct *terms* of type ⊤, for instance `tt`, `id tt`, `id (id tt)` and others not of this family. But there is only one *value* (by which I mean the elements in some unspecified, maybe informal, denotational model).

In case that you feel that the terminology is different, just close this pull request. I know that this is slightly slippery terrain.