### PR TITLE
Replaces all occurrences of 'judgement' with 'judgment'

### DIFF
--- a/extra/extra/InferenceOld.lagda
+++ b/extra/extra/InferenceOld.lagda
@@ -47,10 +47,10 @@ This gives us the grammar:
       L · M                               application
 
 Each of the associated type rules can be read as an algorithm for
-type checking.  For each typing judgement, we label each position
+type checking.  For each typing judgment, we label each position
 as either an _input_ or an _output_.
 
-For the judgement
+For the judgment
 
     Γ ∋ x ⦂ A
 
@@ -73,7 +73,7 @@ type in the input context. For the second rule, the inputs of the
 conclusion determine the inputs of the hypothesis, and the ouptut
 of the hypothesis determines the output of the conclusion.
 
-For the judgement
+For the judgment
 
     Γ ⊢ M ⦂ A
 
@@ -104,7 +104,7 @@ and argument type of the abstraction are carried into the context of
 the hypothesis, and this is why we added the argument type to the
 abstraction.  For the application rule, we add a third hypothesis to
 check whether domain of the function matches the type of the argument;
-this judgement is decidable when both types are given as inputs. The
+this judgment is decidable when both types are given as inputs. The
 inputs of the conclusion determine the inputs of the first two
 hypotheses, the outputs of the first two hypotheses determine the
 inputs of the third hypothesis, and the output of the first hypothesis
@@ -113,15 +113,15 @@ determines the output of the conclusion.
 Converting the above to an algorithm is straightforwart, as is adding
 naturals and fixpoint.  We omit the details.  Instead, we consider a
 detailed description of an approach that requires less obtrusive
-decoration.  The idea is to break the normal typing judgement into two
-judgements, one that produces the type as an output (as above), and
+decoration.  The idea is to break the normal typing judgment into two
+judgments, one that produces the type as an output (as above), and
 another that takes it as an input.
 
 
 ## Synthesising and inheriting types
 
-In addition to the lookup judgement for variables, which will remain
-as before, we now have two judgements for the type of the term.
+In addition to the lookup judgment for variables, which will remain
+as before, we now have two judgments for the type of the term.
 
     Γ ⊢ M ↑ A
     Γ ⊢ M ↓ A
@@ -161,7 +161,7 @@ For instance, we said above that the argument of an application is
 typed by inheritance and that variables are typed by synthesis, giving
 a mismatch if the argument of an application is a variable.  Hence, we
 need a way to treat a synthesized term as if it is inherited.  We
-introduce a new term form, `M ↑` for this purpose.  The typing judgement
+introduce a new term form, `M ↑` for this purpose.  The typing judgment
 checks that the inherited and synthesised types match.
 
 Similarly, we said above that the function of an application is typed
@@ -169,7 +169,7 @@ by synthesis and that abstractions are typed by inheritance, giving a
 mismatch if the function of an application is a variable.  Hence, we
 need a way to treat an inherited term as if it is synthesised.  We
 introduce a new term form `M ↓ A` for this purpose.  The typing
-judgement returns `A` as the synthesized type of the term as a whole,
+judgment returns `A` as the synthesized type of the term as a whole,
 as well as using it as the inherited type for `M`.
 
 The term form `M ↓ A` represents the only place terms need to
@@ -241,7 +241,7 @@ also be referred to as just `Type`.
 ## Syntax
 
 First, we get all our infix declarations out of the way.
-We list separately operators for judgements and terms.
+We list separately operators for judgments and terms.
 
 \begin{code}
 infix   4  _∋_⦂_
@@ -360,7 +360,7 @@ data _∋_⦂_ : Context → Id → Type → Set where
     → Γ , y ⦂ B ∋ x ⦂ A
 \end{code}
 
-As with syntax, the judgements for synthesizing
+As with syntax, the judgments for synthesizing
 and inheriting types are mutually recursive.
 \begin{code}
 data _⊢_↑_ : Context → Term⁺ → Type → Set
@@ -894,7 +894,7 @@ easy to extract the corresponding inherently typed term.  We use the
 name `DB` to refer to the code in
 Chapter [DeBruijn]({{ site.baseurl }}{% link out/plfa/DeBruijn.md %}).
 It is easy to define an _erasure_ function that takes evidence of a
-type judgement into the corresponding inherently typed term.
+type judgment into the corresponding inherently typed term.
 
 First, we give code to erase a context.
 \begin{code}
@@ -912,8 +912,8 @@ Next, we give code to erase a lookup judgment.
 \end{code}
 It just drops the evidence that variable names are distinct.
 
-Finally, we give the code to erase a typing judgement.
-Just as there are two mutually recursive typing judgements,
+Finally, we give the code to erase a typing judgment.
+Just as there are two mutually recursive typing judgments,
 there are two mutually recursive erasure functions.
 \begin{code}
 ∥_∥⁺ : ∀ {Γ M A} → Γ ⊢ M ↑ A → ∥ Γ ∥Γ DB.⊢ A
@@ -930,7 +930,7 @@ there are two mutually recursive erasure functions.
 ∥ ⊢μ ⊢M ∥⁻ =  DB.μ ∥ ⊢M ∥⁻
 ∥ ⊢↑ ⊢M refl ∥⁻ =  ∥ ⊢M ∥⁺
 \end{code}
-Erasure replaces constructors for each typing judgement
+Erasure replaces constructors for each typing judgment
 by the corresponding term constructor from `DB`.  The
 constructors that correspond to switching from synthesized
 to inherited or vice versa are dropped.

--- a/extra/extra/Lambda-new.lagda
+++ b/extra/extra/Lambda-new.lagda
@@ -904,9 +904,9 @@ data Context : Set where
   _,_⦂_ : Context → Id → Type → Context
 \end{code}
 
-### Lookup judgement
+### Lookup judgment
 
-We have two forms of _judgement_.  The first is written
+We have two forms of _judgment_.  The first is written
 
     Γ ∋ x ⦂ A
 
@@ -953,9 +953,9 @@ Constructor `S` takes an additional parameter, which ensures that
 when we look up a variable that it is not _shadowed_ by another
 variable with the same name earlier in the list.
 
-### Typing judgement
+### Typing judgment
 
-The second judgement is written
+The second judgment is written
 
     Γ ⊢ M ⦂ A
 
@@ -1127,8 +1127,8 @@ Here are the typings corresponding to computing two plus two.
 ⊢2+2 : ∅ ⊢ plus · two · two ⦂ `ℕ
 ⊢2+2 = ⊢plus · ⊢two · ⊢two
 \end{code}
-Here the two lookup judgements `∋m` and `∋m′` refer to two different
-bindings of variables named `"m"`.  In contrast, the two judgements `∋n` and
+Here the two lookup judgments `∋m` and `∋m′` refer to two different
+bindings of variables named `"m"`.  In contrast, the two judgments `∋n` and
 `∋n′` both refer to the same binding of `"n"` but accessed in different
 contexts, the first where "n" is the last binding in the context, and
 the second after "m" is bound in the successor branch of the case.
@@ -1202,7 +1202,7 @@ will show how to use Agda to compute type derivations directly.
 ### Lookup is injective
 
 The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
-there is at most one `A` such that the judgement holds.
+there is at most one `A` such that the judgment holds.
 \begin{code}
 ∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
 ∋-injective Z        Z          =  refl

--- a/extra/extra/PropertiesDec.lagda
+++ b/extra/extra/PropertiesDec.lagda
@@ -660,9 +660,9 @@ Now that naming is resolved, let's unpack the first three cases.
 
       Γ , y ⦂ B ∋ x ⦂ A
     
-  There are two subcases, depending on the evidence for this judgement.
+  There are two subcases, depending on the evidence for this judgment.
 
-  + The lookup judgement is evidenced by rule `Z`:
+  + The lookup judgment is evidenced by rule `Z`:
 
         -----------------
         Γ , x ⦂ A ⊢ x ⦂ A
@@ -682,7 +682,7 @@ Now that naming is resolved, let's unpack the first three cases.
 
     - If the variables are unequal we have a contradiction.
 
-  + The lookup judgement is evidenced by rule `S`:
+  + The lookup judgment is evidenced by rule `S`:
 
         x ≢ y
         Γ ∋ x ⦂ A
@@ -763,7 +763,7 @@ Now that naming is resolved, let's unpack the first three cases.
       --------------------------
       Γ ⊢ (L · M) [ y := V ] ⦂ B
 
-  where the second hypothesis follows from the two judgements
+  where the second hypothesis follows from the two judgments
 
       Γ , y ⦂ C ⊢ L ⦂ A ⇒ B
       Γ , y ⦂ C ⊢ M ⦂ A

--- a/extra/extra/SystemF.lagda
+++ b/extra/extra/SystemF.lagda
@@ -11,7 +11,7 @@ module plfa.SystemF where
 ## Fixity declarations
 
 To begin, we get all our infix declarations out of the way.
-We list separately operators for judgements, types, and terms.
+We list separately operators for judgments, types, and terms.
 \begin{code}
 infix  4 _∋⋆_
 infix  4 _∋_

--- a/extra/stlc/StlcNew.lagda
+++ b/extra/stlc/StlcNew.lagda
@@ -621,7 +621,7 @@ consider terms with free variables.  To type a term,
 we must first type its subterms, and in particular in the
 body of an abstraction its bound variable may appear free.
 
-In general, we use typing _judgements_ of the form
+In general, we use typing _judgments_ of the form
 
     Γ ⊢ M ⦂ A
 

--- a/extra/stlc/StlcOld.lagda
+++ b/extra/stlc/StlcOld.lagda
@@ -658,7 +658,7 @@ consider terms with free variables.  To type a term,
 we must first type its subterms, and in particular in the
 body of an abstraction its bound variable may appear free.
 
-In general, we use typing _judgements_ of the form
+In general, we use typing _judgments_ of the form
 
     Γ ⊢ M ∶ A
 

--- a/src/plfa/Bisimulation.lagda
+++ b/src/plfa/Bisimulation.lagda
@@ -203,7 +203,7 @@ and `Value M†` then `Value M`.
 ## Simulation commutes with renaming
 
 The next technical result is that simulation commutes with renaming.
-That is, if `ρ` maps any judgement `Γ ∋ A` to a judgement `Δ ∋ A`,
+That is, if `ρ` maps any judgment `Γ ∋ A` to a judgment `Δ ∋ A`,
 and if `M ~ M†` then `rename ρ M ~ rename ρ M†`.
 
 \begin{code}
@@ -228,7 +228,7 @@ It is more complex than substitution, because where we had one renaming map
 `ρ` here we need two substitution maps, `σ` and `σ†`.
 
 The proof first requires we establish an analogue of extension.
-If `σ` and `σ†` both map any judgement `Γ ∋ A` to a judgement `Δ ⊢ A`,
+If `σ` and `σ†` both map any judgment `Γ ∋ A` to a judgment `Δ ⊢ A`,
 such that for every `x` in `Γ ∋ A` we have `σ x ~ σ† x`,
 then for any `x` in `Γ , B ∋ A` we have `exts σ x ~ exts σ† x`.
 \begin{code}
@@ -246,8 +246,8 @@ The newly introduced variable trivially relates to itself, and otherwise
 we apply renaming to the hypothesis.
 
 With extension under our belts, it is straightforward to show
-substitution commutes.  If `σ` and `σ†` both map any judgement `Γ ∋ A`
-to a judgement `Δ ⊢ A`, such that for every `x` in `Γ ∋ A` we have `σ
+substitution commutes.  If `σ` and `σ†` both map any judgment `Γ ∋ A`
+to a judgment `Δ ⊢ A`, such that for every `x` in `Γ ∋ A` we have `σ
 x ~ σ† x`, and if `M ~ M†`, then `subst σ M ~ subst σ† M†`.
 \begin{code}
 ~subst : ∀ {Γ Δ}

--- a/src/plfa/DeBruijn.lagda
+++ b/src/plfa/DeBruijn.lagda
@@ -154,9 +154,9 @@ addition to the previous correspondences we have
   * `` case_[zero⇒_|suc_⇒_] `` corresponds to `⊢case`
   * `μ_⇒_` corresponds to `⊢μ`
 
-Note the two lookup judgements `∋m` and `∋m′` refer to two
+Note the two lookup judgments `∋m` and `∋m′` refer to two
 different bindings of variables named `"m"`.  In contrast, the
-two judgements `∋n` and `∋n′` both refer to the same binding
+two judgments `∋n` and `∋n′` both refer to the same binding
 of `"n"` but accessed in different contexts, the first where
 "n" is the last binding in the context, and the second after
 "m" is bound in the successor branch of the case.
@@ -206,7 +206,7 @@ incorporates preservation, which no longer requires a separate proof.
 We now begin our formal development.
 
 First, we get all our infix declarations out of the way.
-We list separately operators for judgements, types, and terms.
+We list separately operators for judgments, types, and terms.
 \begin{code}
 infix  4 _⊢_
 infix  4 _∋_
@@ -258,16 +258,16 @@ is a context with two variables in scope, where the outer
 bound one has type `` `ℕ → `ℕ ``, and the inner bound one has
 type `` `ℕ ``.
 
-### Variables and the lookup judgement
+### Variables and the lookup judgment
 
-Inherently typed variables correspond to the lookup judgement.
+Inherently typed variables correspond to the lookup judgment.
 They are represented by de Bruijn indices, and hence also
 correspond to natural numbers.  We write
 
     Γ ∋ A
 
 for variables which in context `Γ` have type `A`.  Their
-formalisation looks exactly like the old lookup judgement, but
+formalisation looks exactly like the old lookup judgment, but
 with all variable names dropped.
 \begin{code}
 data _∋_ : Context → Type → Set where
@@ -289,7 +289,7 @@ constructors `here` and `there` for the element-of relation
 for natural numbers.
 
 For example, consider the following old-style lookup
-judgements:
+judgments:
 
 * `` ∅ , "s" ⦂ `ℕ ⇒ `ℕ , "z" ⦂ `ℕ ∋ "z" ⦂ `ℕ ``
 * `` ∅ , "s" ⦂ `ℕ ⇒ `ℕ , "z" ⦂ `ℕ ∋ "s" ⦂ `ℕ ⇒ `ℕ ``
@@ -307,15 +307,15 @@ In the given context, `"z"` is represented by `Z`
 and `"s"` by `S Z`
 (as the next most recently bound variable).
 
-### Terms and the typing judgement
+### Terms and the typing judgment
 
-Inherently typed terms correspond to the typing judgement.
+Inherently typed terms correspond to the typing judgment.
 We write
 
     Γ ⊢ A
 
 for terms which in context `Γ` has type `A`.  Their
-formalisation looks exactly like the old typing judgement, but
+formalisation looks exactly like the old typing judgment, but
 with all terms and variable names dropped.
 \begin{code}
 data _⊢_ : Context → Type → Set where
@@ -364,7 +364,7 @@ term.  For example, consider the following three terms,
 building up the Church numeral two.
 
 For example, consider the following old-style typing
-judgements:
+judgments:
 
 * `` ∅ , "s" ⦂ `ℕ ⇒ `ℕ , "z" ⦂ `ℕ ⊢ ` "z" ⦂ `ℕ ``
 * `` ∅ , "s" ⦂ `ℕ ⇒ `ℕ , "z" ⦂ `ℕ ⊢ ` "s" ⦂ `ℕ ⇒ `ℕ ``

--- a/src/plfa/Induction.lagda
+++ b/src/plfa/Induction.lagda
@@ -582,11 +582,11 @@ returns `y + x`; the same works for any infix operator.
 
 Returning to the proof of associativity, it may be helpful to view the inductive
 proof (or, equivalently, the recursive definition) as a creation story.  This
-time we are concerned with judgements asserting associativity.
+time we are concerned with judgments asserting associativity.
 
      -- in the beginning, we know nothing about associativity
 
-Now, we apply the rules to all the judgements we know about.  The base
+Now, we apply the rules to all the judgments we know about.  The base
 case tells us that `(zero + n) + p ≡ zero + (n + p)` for every natural
 `n` and `p`.  The inductive case tells us that if `(m + n) + p ≡ m +
 (n + p)` (on the day before today) then
@@ -598,9 +598,9 @@ rule doesn't give us any new judgments.
     (0 + 0) + 0 ≡ 0 + (0 + 0)   ...   (0 + 4) + 5 ≡ 0 + (4 + 5)   ...
 
 Then we repeat the process, so on the next day we know about all the
-judgements from the day before, plus any judgements added by the rules.
+judgments from the day before, plus any judgments added by the rules.
 The base case tells us nothing new, but now the inductive case adds
-more judgements.
+more judgments.
 
     -- on the second day, we know about associativity of 0 and 1
     (0 + 0) + 0 ≡ 0 + (0 + 0)   ...   (0 + 4) + 5 ≡ 0 + (4 + 5)   ...
@@ -622,7 +622,7 @@ You've got the hang of it by now.
     (3 + 0) + 0 ≡ 3 + (0 + 0)   ...   (3 + 4) + 5 ≡ 3 + (4 + 5)   ...
 
 The process continues.  On the _m_'th day we will know all the
-judgements where the first number is less than _m_.
+judgments where the first number is less than _m_.
 
 There is also a completely finite approach to generating the same equations,
 which is left as an exercise for the reader.
@@ -715,7 +715,7 @@ displaying the text
     ?0 : ((m + n) + p) ≡ (m + (n + p))
 
 This indicates that hole 0 is to be filled in with a proof of
-the stated judgement.
+the stated judgment.
 
 We wish to prove the proposition by induction on `m`.  Move
 the cursor into the hole and type `C-c C-c`.  You will be given

--- a/src/plfa/Inference.lagda
+++ b/src/plfa/Inference.lagda
@@ -49,10 +49,10 @@ This gives us the grammar:
       L · M                               application
 
 Each of the associated type rules can be read as an algorithm for
-type checking.  For each typing judgement, we label each position
+type checking.  For each typing judgment, we label each position
 as either an _input_ or an _output_.
 
-For the judgement
+For the judgment
 
     Γ ∋ x ⦂ A
 
@@ -75,7 +75,7 @@ type in the input context. For the second rule, the inputs of the
 conclusion determine the inputs of the hypothesis, and the output
 of the hypothesis determines the output of the conclusion.
 
-For the judgement
+For the judgment
 
     Γ ⊢ M ⦂ A
 
@@ -106,7 +106,7 @@ carried from the term of the conclusion into the context of the
 hypothesis; this works because we added the argument type to the
 abstraction.  For the application rule, we add a third hypothesis to
 check whether the domain of the function matches the type of the
-argument; this judgement is decidable when both types are given as
+argument; this judgment is decidable when both types are given as
 inputs. The inputs of the conclusion determine the inputs of the first
 two hypotheses, the outputs of the first two hypotheses determine the
 inputs of the third hypothesis, and the output of the first hypothesis
@@ -115,15 +115,15 @@ determines the output of the conclusion.
 Converting the above to an algorithm is straightforward, as is adding
 naturals and fixpoint.  We omit the details.  Instead, we consider a
 detailed description of an approach that requires less obtrusive
-decoration.  The idea is to break the normal typing judgement into two
-judgements, one that produces the type as an output (as above), and
+decoration.  The idea is to break the normal typing judgment into two
+judgments, one that produces the type as an output (as above), and
 another that takes it as an input.
 
 
 ## Synthesising and inheriting types
 
-In addition to the lookup judgement for variables, which will remain
-as before, we now have two judgements for the type of the term.
+In addition to the lookup judgment for variables, which will remain
+as before, we now have two judgments for the type of the term.
 
     Γ ⊢ M ↑ A
     Γ ⊢ M ↓ A
@@ -163,7 +163,7 @@ For instance, we said above that the argument of an application is
 typed by inheritance and that variables are typed by synthesis, giving
 a mismatch if the argument of an application is a variable.  Hence, we
 need a way to treat a synthesized term as if it is inherited.  We
-introduce a new term form, `M ↑` for this purpose.  The typing judgement
+introduce a new term form, `M ↑` for this purpose.  The typing judgment
 checks that the inherited and synthesised types match.
 
 Similarly, we said above that the function of an application is typed
@@ -171,7 +171,7 @@ by synthesis and that abstractions are typed by inheritance, giving a
 mismatch if the function of an application is a variable.  Hence, we
 need a way to treat an inherited term as if it is synthesised.  We
 introduce a new term form `M ↓ A` for this purpose.  The typing
-judgement returns `A` as the synthesized type of the term as a whole,
+judgment returns `A` as the synthesized type of the term as a whole,
 as well as using it as the inherited type for `M`.
 
 The term form `M ↓ A` represents the only place terms need to be
@@ -202,7 +202,7 @@ We will formalise the above shortly.
 
 ## Soundness and completeness
 
-What we intend to show is that the typing judgements are
+What we intend to show is that the typing judgments are
 _decidable_.
 
     synthesize : ∀ (Γ : Context) (M : Term⁺)
@@ -277,7 +277,7 @@ also be referred to as just `Type`.
 ## Syntax
 
 First, we get all our infix declarations out of the way.
-We list separately operators for judgements and terms.
+We list separately operators for judgments and terms.
 
 \begin{code}
 infix   4  _∋_⦂_
@@ -398,7 +398,7 @@ data _∋_⦂_ : Context → Id → Type → Set where
     → Γ , y ⦂ B ∋ x ⦂ A
 \end{code}
 
-As with syntax, the judgements for synthesizing
+As with syntax, the judgments for synthesizing
 and inheriting types are mutually recursive.
 \begin{code}
 data _⊢_↑_ : Context → Term⁺ → Type → Set
@@ -577,9 +577,9 @@ ext∋ x≢y _  ⟨ A , Z ⟩       =  x≢y refl
 ext∋ _   ¬∃ ⟨ A , S _ ⊢x ⟩  =  ¬∃ ⟨ A , ⊢x ⟩
 \end{code}
 Given a type `A` and evidence that `Γ , y ⦂ B ∋ x ⦂ A` holds, we must
-demonstrate a contractiction.  If the judgement holds by `Z`, then we
+demonstrate a contractiction.  If the judgment holds by `Z`, then we
 must have that `x` and `y` are the same, which contradicts the first
-assumption. If the judgement holds by `S _ ⊢x` then `⊢x` provides
+assumption. If the judgment holds by `S _ ⊢x` then `⊢x` provides
 evidence that `Γ ∋ x ⦂ A`, which contradicts the second assumption.
 
 Given a context `Γ` and a variable `x`, we decide whether
@@ -995,7 +995,7 @@ easy to extract the corresponding inherently typed term.  We use the
 name `DB` to refer to the code in
 Chapter [DeBruijn][plfa.DeBruijn].
 It is easy to define an _erasure_ function that takes evidence of a
-type judgement into the corresponding inherently typed term.
+type judgment into the corresponding inherently typed term.
 
 First, we give code to erase a type.
 \begin{code}
@@ -1021,8 +1021,8 @@ Next, we give the code to erase a lookup judgment.
 \end{code}
 It simply drops the evidence that variable names are distinct.
 
-Finally, we give the code to erase a typing judgement.
-Just as there are two mutually recursive typing judgements,
+Finally, we give the code to erase a typing judgment.
+Just as there are two mutually recursive typing judgments,
 there are two mutually recursive erasure functions.
 \begin{code}
 ∥_∥⁺ : ∀ {Γ M A} → Γ ⊢ M ↑ A → ∥ Γ ∥Cx DB.⊢ ∥ A ∥Tp
@@ -1039,7 +1039,7 @@ there are two mutually recursive erasure functions.
 ∥ ⊢μ ⊢M ∥⁻           =  DB.μ ∥ ⊢M ∥⁻
 ∥ ⊢↑ ⊢M refl ∥⁻      =  ∥ ⊢M ∥⁺
 \end{code}
-Erasure replaces constructors for each typing judgement
+Erasure replaces constructors for each typing judgment
 by the corresponding term constructor from `DB`.  The
 constructors that correspond to switching from synthesized
 to inherited or vice versa are dropped.

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -972,9 +972,9 @@ data Context : Set where
   _,_⦂_ : Context → Id → Type → Context
 \end{code}
 
-### Lookup judgement
+### Lookup judgment
 
-We have two forms of _judgement_.  The first is written
+We have two forms of _judgment_.  The first is written
 
     Γ ∋ x ⦂ A
 
@@ -1021,9 +1021,9 @@ Constructor `S` takes an additional parameter, which ensures that
 when we look up a variable that it is not _shadowed_ by another
 variable with the same name earlier in the list.
 
-### Typing judgement
+### Typing judgment
 
-The second judgement is written
+The second judgment is written
 
     Γ ⊢ M ⦂ A
 
@@ -1197,8 +1197,8 @@ Here are the typings corresponding to computing two plus two.
 In contrast to our earlier examples, here we have typed `two` and `plus`
 in an arbitrary context rather than the empty context; this makes it easy
 to use them inside other binding contexts as well as at the top level.
-Here the two lookup judgements `∋m` and `∋m′` refer to two different
-bindings of variables named `"m"`.  In contrast, the two judgements `∋n` and
+Here the two lookup judgments `∋m` and `∋m′` refer to two different
+bindings of variables named `"m"`.  In contrast, the two judgments `∋n` and
 `∋n′` both refer to the same binding of `"n"` but accessed in different
 contexts, the first where "n" is the last binding in the context, and
 the second after "m" is bound in the successor branch of the case.
@@ -1269,7 +1269,7 @@ will show how to use Agda to compute type derivations directly.
 ### Lookup is injective
 
 The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
-there is at most one `A` such that the judgement holds.
+there is at most one `A` such that the judgment holds.
 \begin{code}
 ∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
 ∋-injective Z        Z          =  refl

--- a/src/plfa/More.lagda
+++ b/src/plfa/More.lagda
@@ -63,8 +63,8 @@ with multiplication as a primitive operation on numbers.
 ### Typing
 
 The hypothesis of the `con` rule is unusual, in that
-it refers to a typing judgement of Agda rather than a
-typing judgement of the defined calculus.
+it refers to a typing judgment of Agda rather than a
+typing judgment of the defined calculus.
 
     c : ℕ
     --------------- con
@@ -601,7 +601,7 @@ data Context : Set where
   _,_ : Context → Type → Context
 \end{code}
 
-### Variables and the lookup judgement
+### Variables and the lookup judgment
 
 \begin{code}
 data _∋_ : Context → Type → Set where

--- a/src/plfa/Naturals.lagda
+++ b/src/plfa/Naturals.lagda
@@ -613,7 +613,7 @@ of addition.
 
 Again, it is possible to assign our definition a meaning without
 resorting to unpermitted circularities.  We do so by reducing our
-definition to equivalent inference rules for judgements about equality:
+definition to equivalent inference rules for judgments about equality:
 
     n : ℕ
     --------------
@@ -631,7 +631,7 @@ case. It asserts that if adding `m` and `n` gives `p`, then adding `suc m` and
 `n` gives `suc p`.
 
 Again we resort to a creation story, where this time we are
-concerned with judgements about addition:
+concerned with judgments about addition:
 
     -- In the beginning, we know nothing about addition.
 

--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -646,9 +646,9 @@ Now that naming is resolved, let's unpack the first three cases.
 
       Γ , y ⦂ B ∋ x ⦂ A
     
-  There are two subcases, depending on the evidence for this judgement.
+  There are two subcases, depending on the evidence for this judgment.
 
-  + The lookup judgement is evidenced by rule `Z`:
+  + The lookup judgment is evidenced by rule `Z`:
 
         -----------------
         Γ , x ⦂ A ⊢ x ⦂ A
@@ -668,7 +668,7 @@ Now that naming is resolved, let's unpack the first three cases.
 
     - If the variables are unequal we have a contradiction.
 
-  + The lookup judgement is evidenced by rule `S`:
+  + The lookup judgment is evidenced by rule `S`:
 
         x ≢ y
         Γ ∋ x ⦂ A
@@ -749,7 +749,7 @@ Now that naming is resolved, let's unpack the first three cases.
       --------------------------
       Γ ⊢ (L · M) [ y := V ] ⦂ B
 
-  where the second hypothesis follows from the two judgements
+  where the second hypothesis follows from the two judgments
 
       Γ , y ⦂ C ⊢ L ⦂ A ⇒ B
       Γ , y ⦂ C ⊢ M ⦂ A

--- a/src/plfa/Quantitative.lagda
+++ b/src/plfa/Quantitative.lagda
@@ -89,7 +89,7 @@ _ = ∅ , [ 1# ∙ `0 ]⊸ `0 , `0
 \end{code}
 
 
-# Variables and the lookup judgement
+# Variables and the lookup judgment
 
 \begin{code}
 data _∋_ : Precontext → Type → Set where
@@ -170,7 +170,7 @@ _⊛_ : ∀ {γ δ} → Context γ → Matrix γ δ → Context δ
 \end{code}
 
 
-# Terms and the typing judgement
+# Terms and the typing judgment
 
 \begin{code}
 data _⊢_ : ∀ {γ} (Γ : Context γ) (A : Type) → Set where

--- a/src/plfa/Untyped.lagda
+++ b/src/plfa/Untyped.lagda
@@ -113,9 +113,9 @@ We let `Γ` and `Δ` range over contexts.
 
 Show that `Context` is isomorphic to `ℕ`.
 
-## Variables and the lookup judgement
+## Variables and the lookup judgment
 
-Inherently typed variables correspond to the lookup judgement.  The
+Inherently typed variables correspond to the lookup judgment.  The
 rules are as before.
 \begin{code}
 data _∋_ : Context → Type → Set where
@@ -132,15 +132,15 @@ data _∋_ : Context → Type → Set where
 We could write the rules with all instances of `A` and `B`
 replaced by `★`, but arguably it is clearer not to do so.
 
-Because `★` is the only type, the judgement doesn't guarantee anything
+Because `★` is the only type, the judgment doesn't guarantee anything
 useful about types.  But it does ensure that all variables are in
 scope.  For instance, we cannot use `S S Z` in a context that only
 binds two variables.
 
 
-## Terms and the scoping judgement
+## Terms and the scoping judgment
 
-Inherently typed terms correspond to the typing judgement, but with
+Inherently typed terms correspond to the typing judgment, but with
 `★` as the only type.  The result is that we check that terms are
 well-scoped — that is, that all variables they mention are in scope —
 but not that they are well-typed.

--- a/tspl/Assignment4.lagda
+++ b/tspl/Assignment4.lagda
@@ -133,7 +133,7 @@ Remember to indent all code by two spaces.
     _,_ : Context → Type → Context
 \end{code}
 
-### Variables and the lookup judgement
+### Variables and the lookup judgment
 
 \begin{code}
   data _∋_ : Context → Type → Set where

--- a/tspl/Exam.lagda
+++ b/tspl/Exam.lagda
@@ -86,7 +86,7 @@ module Problem2 where
     _,_ : Context → Type → Context
 \end{code}
 
-### Variables and the lookup judgement
+### Variables and the lookup judgment
 
 \begin{code}
   data _∋_ : Context → Type → Set where
@@ -101,7 +101,7 @@ module Problem2 where
       → Γ , B ∋ A
 \end{code}
 
-### Terms and the typing judgement
+### Terms and the typing judgment
 
 \begin{code}
   data _⊢_ : Context → Type → Set where


### PR DESCRIPTION
This patch replaces all occurrences of 'judgement' with 'judgment' per @wadler's instruction.