### PR TITLE
Fixes the character sequence for ℕ in Emacs

### DIFF
--- a/src/plfa/Naturals.lagda
+++ b/src/plfa/Naturals.lagda
@@ -921,7 +921,7 @@ Information on pragmas can be found in the Agda documentation.
 
 This chapter uses the following unicode:
 
-    ℕ  U+2115  DOUBLE-STRUCK CAPITAL N (\bN)
+    ℕ  U+2115  DOUBLE-STRUCK CAPITAL N (\bn)
     →  U+2192  RIGHTWARDS ARROW (\to, \r, \->)
     ∸  U+2238  DOT MINUS (\.-)
     ≡  U+2261  IDENTICAL TO (\==)


### PR DESCRIPTION
The character sequence for obtaining the symbol for the set of natural numbers in Emacs is incorrect. The chapter on natural numbers says it is `\bN` when in fact it is `\bn`. The Verified Functional Programming in Agda book also says it is `\bn`.