### PR TITLE
Adds a full stop after two bullet points in the chapter on relations

### DIFF
--- a/src/plfa/Relations.lagda
+++ b/src/plfa/Relations.lagda
@@ -72,7 +72,7 @@ corresponding inference rules, a trick we will use often from now on.
 
 Both definitions above tell us the same two things:
 
-* _Base case_: for all naturals `n`, the proposition `zero ≤ n` holds
+* _Base case_: for all naturals `n`, the proposition `zero ≤ n` holds.
 * _Inductive case_: for all naturals `m` and `n`, if the proposition
   `m ≤ n` holds, then the proposition `suc m ≤ suc n` holds.
 
@@ -547,7 +547,8 @@ Show that strict inequality satisfies a weak version of trichotomy, in
 the sense that for any `m` and `n` that one of the following holds:
   * `m < n`,
   * `m ≡ n`, or
-  * `m > n`
+  * `m > n`.
+
 Define `m > n` to be the same as `n < m`.
 You will need a suitable data declaration,
 similar to that used for totality.


### PR DESCRIPTION
This patch adds a full stop after two bullet points in the chapter on relations and an empty line after one of them so that there is a proper start of the paragraph following it.