### PR TITLE
Equality chapter: fixes spelling of a word

### DIFF
--- a/src/plfa/Equality.lagda
+++ b/src/plfa/Equality.lagda
@@ -348,7 +348,7 @@ an order that will make sense to the reader.
 
 The proof of monotonicity from
 Chapter [Relations][plfa.Relations]
-can be written in a more readable form by using an anologue of our
+can be written in a more readable form by using an analogue of our
 notation for `≡-reasoning`.  Define `≤-reasoning` analogously, and use
 it to write out an alternative proof that addition is monotonic with
 regard to inequality.  Rewrite both `+-monoˡ-≤` and `+-mono-≤`.


### PR DESCRIPTION
This patch fixes a spelling of "anologue" in the chapter on equality.