### PR TITLE
Equality chapter: adds a missing article for a countable noun

### DIFF
--- a/src/plfa/Equality.lagda
+++ b/src/plfa/Equality.lagda
@@ -466,7 +466,7 @@ when feasible.
 
 ## Rewriting expanded
 
-The `rewrite` notation is in fact shorthand for an appropriate use of `with`
+The `rewrite` notation is in fact a shorthand for an appropriate use of `with`
 abstraction:
 \begin{code}
 even-comm′ : ∀ (m n : ℕ)


### PR DESCRIPTION
This patch adds a missing article in front of a countable noun "shorthand".