### PR TITLE
Isomorphism: inserts a line break for a new paragraph

### DIFF
--- a/src/plfa/Isomorphism.lagda
+++ b/src/plfa/Isomorphism.lagda
@@ -151,6 +151,7 @@ of four things:
 + A function `from` from `B` back to `A`,
 + Evidence `from∘to` asserting that `from` is a *left-inverse* for `to`,
 + Evidence `to∘from` asserting that `from` is a *right-inverse* for `to`.
+
 In particular, the third asserts that `from ∘ to` is the identity, and
 the fourth that `to ∘ from` is the identity, hence the names.
 The declaration `open _≃_` makes available the names `to`, `from`,


### PR DESCRIPTION
In the isomorphism chapter, this inserts a line break so that a new paragraph starts after an enumeration. To me it makes sense to do this because otherwise the text talks about the third bullet point while under the fourth bullet point.