### PR TITLE
Isomorphism: replaces a conjunction with an article

### DIFF
--- a/src/plfa/Isomorphism.lagda
+++ b/src/plfa/Isomorphism.lagda
@@ -312,7 +312,7 @@ open ≃-Reasoning
 
 We also need the notion of _embedding_, which is a weakening of
 isomorphism.  While an isomorphism shows that two types are in
-one-to-one correspondence, and embedding shows that the first type is
+one-to-one correspondence, an embedding shows that the first type is
 included in the second; or, equivalently, that there is a many-to-one
 correspondence between the second type and the first.
 


### PR DESCRIPTION
This patch fixes wording in the chapter on isomorphism. It replaces "and" with "an", which is what I believe was intended in the sentence.