### PR TITLE
Connectives: disambiguates equation referred to

### DIFF
--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -121,8 +121,8 @@ constructor is the identity over products:
 η-× ⟨ x , y ⟩ = refl
 \end{code}
 The pattern matching on the left-hand side is essential, since
-replacing `w` by `⟨ x , y ⟩` allows both sides of the equation to
-simplify to the same term.
+replacing `w` by `⟨ x , y ⟩` allows both sides of the
+propositional equality to simplify to the same term.
 
 We set the precedence of conjunction so that it binds less
 tightly than anything save disjunction:


### PR DESCRIPTION
In the chapter on connectives, this patch disambiguates equation being referred to. In the definition of `η-×`:

```agda
η-× : ∀ {A B : Set} (w : A × B) → ⟨ proj₁ w , proj₂ w ⟩ ≡ w
η-× ⟨ x , y ⟩ = refl
```

I'd argue that _the_ equation is the one defining `η-×` and that the propositional equality in the conclusion is where simplification happens due to the pattern matching. However, the text says that simplification happens on both sides of the equation, implying it happens around `=`, which isn't the case. The simplification happens in `⟨ proj₁ w , proj₂ w ⟩ ≡ w`, therefore on both sides of the propositional equality.

To make the text clear, I propose to change it so that it refers to the propositional equality instead of the equation.