### PR TITLE
Connectives: clarifies what simplification a pattern match enables

### DIFF
--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -258,8 +258,8 @@ value of type `⊤` must be equal to `tt`:
 η-⊤ tt = refl
 \end{code}
 The pattern matching on the left-hand side is essential.  Replacing
-`w` by `tt` allows both sides of the equation to simplify to the
-same term.
+`w` by `tt` allows both sides of the propositional equality to
+simplify to the same term.
 
 We refer to `⊤` as the _unit_ type. And, indeed,
 type `⊤` has exactly once member, `tt`.  For example, the following


### PR DESCRIPTION
Just like in the pull request #177, in the chapter on connectives this patch replaces "equation" with "propositional equality" to clarify where simplification happens.