### PR TITLE
Connectives: fixes a typo, once -> one

### DIFF
--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -262,7 +262,7 @@ The pattern matching on the left-hand side is essential.  Replacing
 same term.
 
 We refer to `⊤` as the _unit_ type. And, indeed,
-type `⊤` has exactly once member, `tt`.  For example, the following
+type `⊤` has exactly one member, `tt`.  For example, the following
 function enumerates all possible arguments of type `⊤`:
 \begin{code}
 ⊤-count : ⊤ → ℕ


### PR DESCRIPTION
In the chapter on connectives, this patch changes "once member" to "one member" in a sentence:

"And, indeed, type `⊤` has exactly once member, `tt`."