### PR TITLE
Connectives: changes a punctuation before a code block

### DIFF
--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -450,7 +450,7 @@ paradoxical situation.  Given evidence that `⊥` holds, we might
 conclude anything!  This is a basic principle of logic, known in
 medieval times by the Latin phrase _ex falso_, and known to children
 through phrases such as "if pigs had wings, then I'd be the Queen of
-Sheba".  We formalise it as follows.
+Sheba".  We formalise it as follows:
 \begin{code}
 ⊥-elim : ∀ {A : Set}
   → ⊥


### PR DESCRIPTION
In the chapter on connectives, this patch replaces an occurrence of "as follows." with "as follows:". This is the only place in the whole `src` directory where a full stop was used after "as follows", unlike a colon that was used for 28 times.