### PR TITLE
Connectives: fixes the text of exercises to match names of proofs

### DIFF
--- a/src/plfa/Connectives.lagda
+++ b/src/plfa/Connectives.lagda
@@ -491,7 +491,7 @@ is the identity of sums _up to isomorphism_.
 
 #### Exercise `⊥-identityˡ` (recommended)
 
-Show zero is the left identity of addition.
+Show empty is the left identity of sums up to isomorphism.
 
 \begin{code}
 -- Your code goes here
@@ -499,7 +499,7 @@ Show zero is the left identity of addition.
 
 #### Exercise `⊥-identityʳ`
 
-Show zero is the right identity of addition. 
+Show empty is the right identity of sums up to isomorphism.
 
 \begin{code}
 -- Your code goes here


### PR DESCRIPTION
In the chapter on connectives, this patch fixes the text of exercises in the section _False is empty_ to match the given proof names.

Closes #187.