### PR TITLE
Getting Started: pins down software versions so badges match links

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ or by downloading [the zip archive](https://github.com/plfa/plfa.github.io/archi
     git clone https://github.com/plfa/plfa.github.io 
 
 Finally, we need to let Agda know where to find the standard library.
-For this, you can follow the instructions [here](https://agda.readthedocs.io/en/latest/tools/package-system.html#example-using-the-standard-library).
+For this, you can follow the instructions [here](https://agda.readthedocs.io/en/v2.5.4.2/tools/package-system.html#example-using-the-standard-library).
 
 It is possible to set up PLFA as an Agda library as well.
 If you are trying to complete the exercises found in the `tspl` folder, or otherwise want to import modules from the book, you need to do this.

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ permalink: /GettingStarted/
 
 There are several tools you need to work with PLFA:
 
-  - [Agda](https://agda.readthedocs.io/en/latest/getting-started/installation.html)
-  - [Agda standard library](https://github.com/agda/agda-stdlib)
+  - [Agda](https://agda.readthedocs.io/en/v2.5.4.2/getting-started/installation.html)
+  - [Agda standard library](https://github.com/agda/agda-stdlib/tree/5819a4dd9c965296224944f05b1481805649bdc2)
 
 For most of the tools, you can simply follow their respective build instructions.
 We list the versions of our dependencies on the badges above.


### PR DESCRIPTION
On the [Getting Started](https://plfa.github.io/GettingStarted/) page, there is a slight mismatch between badges on the top and corresponding links in the text:

- The Agda badge indicates version 2.5.4.2, while the text bellow links to the latest version. At the moment the latest Agda version is 2.5.4.2, but this can get out of sync.
- The standard library badge indicates version 0.17, while the text bellow links to the front page of the library repository, which might have changes that are not in version 0.17.

This patch pins down, i.e., fixes links to versions of Agda and the standard library so that they match versions indicated by the badges.