### PR TITLE
four and fourᶜ seems mixed

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -173,7 +173,8 @@ sucᶜ : Term
 sucᶜ = ƛ "n" ⇒ `suc (` "n")
 
 fourᶜ : Term
-fourᶜ = plusᶜ · twoᶜ · twoᶜ · sucᶜ · `zero
+fourᶜ = plusᶜ · twoᶜ · twoᶜ
+
 \end{code}
 The Church numeral for two takes two arguments `s` and `z`
 and applies `s` twice to `z`.
@@ -856,7 +857,7 @@ _ =
 
 And here is a similar sample reduction for Church numerals:
 \begin{code}
-_ : fourᶜ —↠ `suc `suc `suc `suc `zero
+_ : fourᶜ · sucᶜ · `zero —↠ `suc `suc `suc `suc `zero
 _ =
   begin
     (ƛ "m" ⇒ ƛ "n" ⇒ ƛ "s" ⇒ ƛ "z" ⇒ ` "m" · ` "s" · (` "n" · ` "s" · ` "z"))

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -174,7 +174,6 @@ sucᶜ = ƛ "n" ⇒ `suc (` "n")
 
 fourᶜ : Term
 fourᶜ = plusᶜ · twoᶜ · twoᶜ
-
 \end{code}
 The Church numeral for two takes two arguments `s` and `z`
 and applies `s` twice to `z`.


### PR DESCRIPTION
It is a matter of definition but superscript c seems to be used for Church numeral. and If my understanding about Church numeral is correct, the fix is what you intended. 

Agda type checks correctly with the change.