### PR TITLE
Negation: changes 'give' to 'given'

### DIFF
--- a/src/plfa/Negation.lagda
+++ b/src/plfa/Negation.lagda
@@ -300,7 +300,7 @@ The best way to explain this code is to develop it interactively:
 
     em-irrefutable k = ?
 
-Given evidence `k` that `¬ (A ⊎ ¬ A)`, that is, a function that give a
+Given evidence `k` that `¬ (A ⊎ ¬ A)`, that is, a function that given a
 value of type `A ⊎ ¬ A` returns a value of the empty type, we must fill
 in `?` with a term that returns a value of the empty type.  The only way
 we can get a value of the empty type is by applying `k` itself, so let's


### PR DESCRIPTION
In the chapter on negation, this patch changes 'give' to 'given' as it should be in an explanation of a proof for the irrefutability of the excluded middle.