### PR TITLE
Quantifiers: removes a back-tick that causes a formatting problem

### DIFF
--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -306,7 +306,7 @@ consisting of zero and the evidence that twice zero is zero.
 * If the number is even because it is one more than an odd number,
 then we apply the induction hypothesis to give a number `m` and
 evidence that `1 + m * 2 ≡ n`. We return a pair consisting of `suc m`
-and evidence that `suc m * 2` ≡ suc n`, which is immediate after
+and evidence that `suc m * 2 ≡ suc n`, which is immediate after
 substituting for `n`.
 
 * If the number is odd because it is the successor of an even number,


### PR DESCRIPTION
In the chapter on quantifiers, this patch removes a back-tick that causes a formatting problem in the text explaining the proof of `even-∃`. With the back-tick in place, the text "which is immediate after substituting for" would end up highlighted like `which is immediate after substituting for`.

I'll just use this pull request to remind you of two other pending pull requests: PR #196 and PR #199. Let me know if I should make any changes there.