### PR TITLE
Quantifiers: fixes explanation of the proof for odd-∃

### DIFF
--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -311,9 +311,9 @@ substituting for `n`.
 
 * If the number is odd because it is the successor of an even number,
 then we apply the induction hypothesis to give a number `m` and
-evidence that `m * 2 ≡ n`. We return a pair consisting of `suc m` and
-evidence that `1 + m * 2 ≡ suc n`, which is immediate after
-substituting for `n`.
+evidence that `m * 2 ≡ n'`. We return a pair consisting of `m` and
+evidence that `1 + m * 2 ≡ suc n'`, which is immediate after
+substituting for `n'`.
 
 This completes the proof in the forward direction.
 

--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -311,9 +311,9 @@ substituting for `n`.
 
 * If the number is odd because it is the successor of an even number,
 then we apply the induction hypothesis to give a number `m` and
-evidence that `m * 2 ≡ n'`. We return a pair consisting of `m` and
-evidence that `1 + m * 2 ≡ suc n'`, which is immediate after
-substituting for `n'`.
+evidence that `m * 2 ≡ n`. We return a pair consisting of `m` and
+evidence that `1 + m * 2 ≡ suc n`, which is immediate after
+substituting for `n`.
 
 This completes the proof in the forward direction.
 


### PR DESCRIPTION
As explained in issue #206, in the chapter on quantifiers the text explaining the proof for `odd-∃` is confusing. This patch fixes the explanation by using a fresh name `n'` instead of `n`.