### PR TITLE
Properties, DeBrujin, More: Missing unicode sections added

### DIFF
--- a/src/plfa/DeBruijn.lagda
+++ b/src/plfa/DeBruijn.lagda
@@ -1351,3 +1351,16 @@ The relation between the two approaches approximates the
 golden ratio: raw terms with a separate typing relation
 require about 1.6 times as much code as inherently-typed terms
 with de Bruijn indices.
+
+## Unicode
+
+This chapter uses the following unicode:
+
+    σ  U+03C3  GREEK SMALL LETTER SIGMA (\Gs or \sigma)
+    ₀  U+2080  SUBSCRIPT ZERO (\_0)
+    ₃  U+20B3  SUBSCRIPT THREE (\_3)
+    ₄  U+2084  SUBSCRIPT FOUR (\_4)
+    ₅  U+2085  SUBSCRIPT FIVE (\_5)
+    ₆  U+2086  SUBSCRIPT SIX (\_6)
+    ₇  U+2087  SUBSCRIPT SEVEN (\_7)
+    ≠  U+2260  NOT EQUAL TO (\=n)

--- a/src/plfa/More.lagda
+++ b/src/plfa/More.lagda
@@ -1215,3 +1215,10 @@ to confirm it returns the expected answer:
 -- Your code goes here
 \end{code}
 
+## Unicode
+
+This chapter uses the following unicode:
+
+    σ  U+03C3  GREEK SMALL LETTER SIGMA (\Gs or \sigma)
+    †  U+2020  DAGGER (\dag)
+    ‡  U+2021  DOUBLE DAGGER (\ddag)

--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -1555,3 +1555,26 @@ false, give a counterexample:
 
 Are all properties preserved in this case? Are there any
 other alterations we would wish to make to the system?
+
+## Unicode
+
+This chapter uses the following unicode:
+
+    ƛ  U+019B  LATIN SMALL LETTER LAMBDA WITH STROKE (\Gl-)
+    Δ  U+0394  GREEK CAPITAL LETTER DELTA (\GD or \Delta)
+    β  U+03B2  GREEK SMALL LETTER BETA (\Gb or \beta)
+    δ  U+03B4  GREEK SMALL LETTER DELTA (\Gd or \delta)
+    μ  U+03BC  GREEK SMALL LETTER MU (\Gm or \mu)
+    ξ  U+03BE  GREEK SMALL LETTER XI (\Gx or \xi)
+    ρ  U+03B4  GREEK SMALL LETTER RHO (\Gr or \rho)
+    ᵢ  U+1D62  LATIN SUBSCRIPT SMALL LETTER I (\_i)
+    ᶜ  U+1D9C  MODIFIER LETTER SMALL C (̂\^c)
+    –  U+2013  EM DASH (\em)
+    ₄  U+2084  SUBSCRIPT FOUR (\_4)
+    ↠  U+21A0  RIGHTWARDS TWO HEADED ARROW (\rr-)
+    ⇒  U+21D2  RIGHTWARDS DOUBLE ARROW (\=>)
+    ∅  U+2205  EMPTY SET (\0)
+    ∋  U+220B  CONTAINS AS MEMBER (\ni)
+    ≟  U+225F  QUESTIONED EQUAL TO (\?=)
+    ⊢  U+22A2  RIGHT TACK (\vdash or \|-)
+    ⦂  U+2982  Z NOTATION TYPE COLON (\:)


### PR DESCRIPTION
The three chapters does not have unicode section, I added unicode sections for them.
As I did not collect unicode characters manually, I implemented some perl script to collect in the following criteria.

- If any unicode character that is appeared in the current chapter is picked up in unicode section, if the character is appeared at most once in any preceding chapters.

I sorted the character based on unicode code point.