### PR TITLE
Quantifiers: makes spacing consistent with the rest of the code

### DIFF
--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -239,7 +239,7 @@ postulate
 Show that an existential of conjunctions implies a conjunction of existentials:
 \begin{code}
 postulate
-  ∃×-implies-×∃ : ∀ {A : Set} { B C : A → Set } →
+  ∃×-implies-×∃ : ∀ {A : Set} {B C : A → Set} →
     ∃[ x ] (B x × C x) → (∃[ x ] B x) × (∃[ x ] C x)
 \end{code}
 Does the converse hold? If so, prove; if not, explain why.


### PR DESCRIPTION
In the chapter on quantifiers, this patch removes redundant spacing inside curly braces in an argument list to a function. This makes it consistent with the rest of the code.