### PR TITLE
Decidable: uses a more specific relation symbol

### DIFF
--- a/src/plfa/Decidable.lagda
+++ b/src/plfa/Decidable.lagda
@@ -94,8 +94,8 @@ The first and last clauses of this definition resemble the two
 constructors of the corresponding inductive datatype, while the
 middle clause arises because there is no possible evidence that
 `suc m ≤ zero` for any `m`.
-For example, we can compute that `2 ≤ 4` holds,
-and we can compute that `4 ≤ 2` does not hold:
+For example, we can compute that `2 ≤ᵇ 4` holds,
+and we can compute that `4 ≤ᵇ 2` does not hold:
 \begin{code}
 _ : (2 ≤ᵇ 4) ≡ true
 _ =


### PR DESCRIPTION
In the chapter on decidables, this patch makes usage of a more specific relation symbol to make it clear that it is the `_≤ᵇ_` function that is talked about instead of the relation `_≤_`.