### PR TITLE
Decidable: clarifies a lack of need for a case analysis

### DIFF
--- a/src/plfa/Decidable.lagda
+++ b/src/plfa/Decidable.lagda
@@ -155,7 +155,7 @@ T→≡ false ()
 If `b` is true then `T b` is inhabited by `tt` and `b ≡ true` is inhabited
 by `refl`, while if `b` is false then `T b` in uninhabited.
 
-In the reverse direction, there is no need for a case analysis:
+In the reverse direction, there is no need for a case analysis on the boolean `b`:
 \begin{code}
 ≡→T : ∀ {b : Bool} → b ≡ true → T b
 ≡→T refl  =  tt


### PR DESCRIPTION
In the chapter on decidables, this patch clarifies why is there no need for a case analysis. In particular, it is not that there is no need for a case analysis at all, but rather for one on the boolean `b` (there is a case analysis for the values of the `b ≡ true` type as otherwise there would be no case for `refl`).