### PR TITLE
Decidable: replaces 'is' with 'if'

### DIFF
--- a/src/plfa/Decidable.lagda
+++ b/src/plfa/Decidable.lagda
@@ -400,7 +400,7 @@ Most readers will be familiar with the logical connectives for booleans.
 Each of these extends to decidables.
 
 The conjunction of two booleans is true if both are true,
-and false is either is false:
+and false if either is false:
 \begin{code}
 infixr 6 _∧_
 


### PR DESCRIPTION
In the chapter on decidables, this patch fixes a mistake where "is" was put in place of "if".