### PR TITLE
Lists: adds an intermediate step in a proof for ++-assoc

### DIFF
--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -162,6 +162,8 @@ about numbers.  Here is the proof that append is associative:
   begin
     (x ∷ xs ++ ys) ++ zs
   ≡⟨⟩
+    x ∷ (xs ++ ys) ++ zs
+  ≡⟨⟩
     x ∷ ((xs ++ ys) ++ zs)
   ≡⟨ cong (x ∷_) (++-assoc xs ys zs) ⟩
     x ∷ (xs ++ (ys ++ zs))


### PR DESCRIPTION
In the chapter on lists, this patch adds an intermediate step in a proof of `++-assoc`. Without this step it was not obvious to me why the equation preceding it is equal to the one following it. The introduction of this intermediate step should make it easier to see why.