### PR TITLE
Lists: updates the definition of a higher-order function

### DIFF
--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -466,7 +466,7 @@ Now the time to reverse a list is linear in the length of the list.
 
 Map applies a function to every element of a list to generate a corresponding list.
 Map is an example of a _higher-order function_, one which takes a function as an
-argument and returns a function as a result:
+argument or returns a function as a result:
 \begin{code}
 map : ∀ {A B : Set} → (A → B) → List A → List B
 map f []        =  []


### PR DESCRIPTION
In the chapter on lists, this patch replaces an "and" with an "or" in the definition of a higher-order function. Either criterion is enough to meet the definition, hence "or".