### PR TITLE
Lists: removes a your-code-goes-here snippet

### DIFF
--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -939,10 +939,6 @@ _∘′_ : ∀ {ℓ₁ ℓ₂ ℓ₃ : Level} {A : Set ℓ₁} {B : Set ℓ₂} 
 (g ∘′ f) x  =  g (f x)
 \end{code}
 
-\begin{code}
--- Your code goes here
-\end{code}
-
 Show that `Any` and `All` satisfy a version of De Morgan's Law:
 \begin{code}
 postulate


### PR DESCRIPTION
In the chapter on lists, this patch removes a your-code-goes-here code snippet as there is nothing to implement there; an implementation for `_∘′_` is provided just above it.