### PR TITLE
Quantifiers: removes unused imports

### DIFF
--- a/src/plfa/Quantifiers.lagda
+++ b/src/plfa/Quantifiers.lagda
@@ -16,15 +16,12 @@ This chapter introduces universal and existential quantification.
 
 \begin{code}
 import Relation.Binary.PropositionalEquality as Eq
-open Eq using (_≡_; refl; sym; trans; cong)
-open Eq.≡-Reasoning
+open Eq using (_≡_; refl)
 open import Data.Nat using (ℕ; zero; suc; _+_; _*_)
-open import Data.Nat.Properties.Simple using (+-suc)
 open import Relation.Nullary using (¬_)
-open import Function using (_∘_)
-open import Data.Product using (_×_; proj₁; proj₂) renaming (_,_ to ⟨_,_⟩)
-open import Data.Sum using (_⊎_; inj₁; inj₂)
-open import plfa.Isomorphism using (_≃_; ≃-sym; ≃-trans; _≲_; extensionality)
+open import Data.Product using (_×_; proj₁) renaming (_,_ to ⟨_,_⟩)
+open import Data.Sum using (_⊎_)
+open import plfa.Isomorphism using (_≃_; extensionality)
 \end{code}
 
 


### PR DESCRIPTION
In the chapter on quantifiers, this patch removes unused imports. The chapter file type-checks with these changes.