### PR TITLE
Isomorphism: removes unused imports

### DIFF
--- a/src/plfa/Isomorphism.lagda
+++ b/src/plfa/Isomorphism.lagda
@@ -21,7 +21,7 @@ distributivity.
 
 \begin{code}
 import Relation.Binary.PropositionalEquality as Eq
-open Eq using (_≡_; refl; sym; trans; cong; cong-app)
+open Eq using (_≡_; refl; cong; cong-app)
 open Eq.≡-Reasoning
 open import Data.Nat using (ℕ; zero; suc; _+_)
 open import Data.Nat.Properties using (+-comm)


### PR DESCRIPTION
In the chapter on isomorphism, this patch removes unused imports. The chapter file type-checks with this update.