### PR TITLE
Lists: fixes the plural and names of analogues in exercise text

### DIFF
--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -995,9 +995,9 @@ the head and tail of the list.
 
 #### Exercise `any?` (stretch)
 
-Just as `All` has analogues `all` and `all?` which determine whether a
+Just as `All` has analogues `all` and `All?` which determine whether a
 predicate holds for every element of a list, so does `Any` have
-analogues `any` and `any?` which determine whether a predicates holds
+analogues `any` and `Any?` which determine whether a predicate holds
 for some element of a list.  Give their definitions.
 
 \begin{code}


### PR DESCRIPTION
In the chapter on lists, this patch fixes the plural of a noun as well as names of analogues in an exercise `any?`.