### PR TITLE
Lambda: removes a mention of a non-existing name

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -362,7 +362,7 @@ data Value : Term → Set where
     → Value (`suc V)
 \end{code}
 
-We let `V` and `W` range over values.
+We let `V` range over values.
 
 
 ### Formal vs informal


### PR DESCRIPTION
In the chapter on lambda calculus, this patch removes a mention of the non-existing name `W` in the definition of the `Value` type constructor.