### PR TITLE
Typo: that ~> than

### DIFF
--- a/src/plfa/Relations.lagda
+++ b/src/plfa/Relations.lagda
@@ -144,7 +144,7 @@ We declare the precedence for comparison as follows:
 infix 4 _≤_
 \end{code}
 We set the precedence of `_≤_` at level 4, so it binds less tightly
-that `_+_` at level 6 and hence `1 + 2 ≤ 3` parses as `(1 + 2) ≤ 3`.
+than `_+_` at level 6 and hence `1 + 2 ≤ 3` parses as `(1 + 2) ≤ 3`.
 We write `infix` to indicate that the operator does not associate to
 either the left or right, as it makes no sense to parse `1 ≤ 2 ≤ 3` as
 either `(1 ≤ 2) ≤ 3` or `1 ≤ (2 ≤ 3)`.


### PR DESCRIPTION
Fixes a minor typo.