### PR TITLE
Fixes a quiz question involving twoᶜ

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -653,7 +653,7 @@ What does the following term step to?
 
 What does the following term step to?  (Where `two` and `sucᶜ` are as defined above.)
 
-    two · sucᶜ · `zero  —→  ???
+    twoᶜ · sucᶜ · `zero  —→  ???
 
 1.  `` sucᶜ · (sucᶜ · `zero) ``
 2.  `` (ƛ "z" ⇒ sucᶜ · (sucᶜ · ` "z")) · `zero ``


### PR DESCRIPTION
In the chapter on lambda calculus, this patch fixes a quiz question by replacing `two` with `twoᶜ`.

Closes #252.