### PR TITLE
Lists: Change in the order of hypothesis in ++-assoc's description

### DIFF
--- a/src/plfa/Lists.lagda
+++ b/src/plfa/Lists.lagda
@@ -181,11 +181,11 @@ invocation of the proof, in this case `++-assoc xs ys zs`.
 Recall that Agda supports [sections][plfa.Induction#sections].
 Applying `cong (x ∷_)` promotes the inductive hypothesis:
 
-    xs ++ (ys ++ zs) ≡ (xs ++ ys) ++ zs
+    (xs ++ ys) ++ zs ≡ xs ++ (ys ++ zs)
 
 to the equality:
 
-    x ∷ (xs ++ (ys ++ zs)) ≡ x ∷ ((xs ++ ys) ++ zs)
+    x ∷ ((xs ++ ys) ++ zs) ≡ x ∷ (xs ++ (ys ++ zs))
 
 which is needed in the proof.
 


### PR DESCRIPTION
The order of the inductive hypothesis in the description of `++-assoc` doesn't match its order in the proof.