### PR TITLE
Lambda: fixes the description of the lookup judgment

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -1058,7 +1058,7 @@ The constructors `Z` and `S` correspond roughly to the constructors
 `here` and `there` for the element-of relation `_∈_` on lists.
 Constructor `S` takes an additional parameter, which ensures that
 when we look up a variable that it is not _shadowed_ by another
-variable with the same name earlier in the list.
+variable with the same name latter in the list.
 
 ### Typing judgment
 


### PR DESCRIPTION
In the chapter on lambda calculus, this patch fixes the description of lookup judgment. A variable with the same name can be shadowed only by a latter element in the list, and not by by an element that came before it.