### PR TITLE
Lambda: fixes the description of lookup judgment

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -1058,7 +1058,7 @@ The constructors `Z` and `S` correspond roughly to the constructors
 `here` and `there` for the element-of relation `_∈_` on lists.
 Constructor `S` takes an additional parameter, which ensures that
 when we look up a variable that it is not _shadowed_ by another
-variable with the same name earlier in the list.
+variable with the same name to its left in the list.
 
 ### Typing judgment
 


### PR DESCRIPTION
Related to the closed pull request #278, this replaces 'earlier' by 'to its left' so let me know if that would work now.