### PR TITLE
Properties: Fixed italics and capitalization

### DIFF
--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -79,7 +79,7 @@ Agda code that can compute for us the reduction sequence of `plus ·
 two · two`, and its Church numeral variant.
 
 (The development in this chapter was inspired by the corresponding
-development in _Software Foundations_, volume _Programming Language
+development in _Software Foundations_, Volume _Programming Language
 Foundations_, Chapter _StlcProp_.  It will turn out that one of our technical choices
 — to introduce an explicit judgment `Γ ∋ x ⦂ A` in place of
 treating a context as a function from identifiers to types —

--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -79,8 +79,8 @@ Agda code that can compute for us the reduction sequence of `plus ·
 two · two`, and its Church numeral variant.
 
 (The development in this chapter was inspired by the corresponding
-development in _Software Foundations, volume _Programming Language
-Foundations_, chapter _StlcProp_.  It will turn out that one of our technical choices
+development in _Software Foundations_, volume _Programming Language
+Foundations_, Chapter _StlcProp_.  It will turn out that one of our technical choices
 — to introduce an explicit judgment `Γ ∋ x ⦂ A` in place of
 treating a context as a function from identifiers to types —
 permits a simpler development. In particular, we can prove substitution preserves


### PR DESCRIPTION
The italic style wasn't closed after the book name. Also, the word "chapter" was capitalized in previous chapters when referring to a specific one. I'm not sure about capitalizing "volume".