### PR TITLE
Lambda: adds a full stop at the end of a sentence

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -1338,7 +1338,7 @@ nope₁ (() · _)
 \end{code}
 
 As a second example, here is a formal proof that it is not possible to
-type `` ƛ "x" ⇒ ` "x" · ` "x" `` It cannot be typed, because
+type `` ƛ "x" ⇒ ` "x" · ` "x" ``. It cannot be typed, because
 doing so requires types `A` and `B` such that `A ⇒ B ≡ A`:
 
 \begin{code}


### PR DESCRIPTION
In the chapter on lambda calculus, this simple patch adds a full stop at the end of a sentence.