### PR TITLE
Replaced occurrences of 'De Bruijn' with 'de Bruijn'

### DIFF
--- a/extra/extra/Lambda-new.lagda
+++ b/extra/extra/Lambda-new.lagda
@@ -38,7 +38,7 @@ progress and preservation.  Following chapters will look at a number
 of variants of lambda calculus.
 
 Be aware that the approach we take here is _not_ our recommended
-approach to formalisation.  Using De Bruijn indices and
+approach to formalisation.  Using de Bruijn indices and
 inherently-typed terms, as we will do in
 Chapter [DeBruijn]({{ site.baseurl }}{% link out/plta/DeBruijn.md %}),
 leads to a more compact formulation.  Nonetheless, we begin with named

--- a/index.md
+++ b/index.md
@@ -33,7 +33,7 @@ Pull requests are encouraged.
 
   - [Lambda](/Lambda/): Introduction to Lambda Calculus
   - [Properties](/Properties/): Progress and Preservation
-  - [DeBruijn](/DeBruijn/): Inherently typed De Bruijn representation
+  - [DeBruijn](/DeBruijn/): Inherently typed de Bruijn representation
   - [More](/More/): Additional constructs of simply-typed lambda calculus
   - [Bisimulation](/Bisimulation/): Relating reductions systems
   - [Inference](/Inference/): Bidirectional type inference

--- a/src/plfa/DeBruijn.lagda
+++ b/src/plfa/DeBruijn.lagda
@@ -110,10 +110,10 @@ raw terms by the more sophisticated type `Γ ⊢ A` of inherently
 typed terms, which in context `Γ` have type `A`.
 
 While these two choices fit well, they are independent.  One
-can use De Bruijn indices in raw terms, or (with more
+can use de Bruijn indices in raw terms, or (with more
 difficulty) have inherently typed terms with names.  In
 Chapter [Untyped][plfa.Untyped],
-we will introduce terms with De Bruijn indices that
+we will introduce terms with de Bruijn indices that
 are inherently scoped but not typed.
 
 
@@ -412,7 +412,7 @@ postulating an `impossible` term, just as we did
 [here][plfa.Lambda#impossible].
 
 Given the above, we can convert a natural to a corresponding
-De Bruijn index, looking up its type in the context:
+de Bruijn index, looking up its type in the context:
 \begin{code}
 count : ∀ {Γ} → (n : ℕ) → Γ ∋ lookup Γ n
 count {Γ , _} zero     =  Z

--- a/src/plfa/Denotational.lagda
+++ b/src/plfa/Denotational.lagda
@@ -251,7 +251,7 @@ init-last {Γ} γ = extensionality lemma
   lemma (S x)  =  refl
 \end{code}
 
-The nth function takes a De Bruijn index and finds the corresponding
+The nth function takes a de Bruijn index and finds the corresponding
 value in the environment.
 
 \begin{code}

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -31,7 +31,7 @@ progress and preservation.  Following chapters will look at a number
 of variants of lambda calculus.
 
 Be aware that the approach we take here is _not_ our recommended
-approach to formalisation.  Using De Bruijn indices and
+approach to formalisation.  Using de Bruijn indices and
 inherently-typed terms, as we will do in
 Chapter [DeBruijn][plfa.DeBruijn],
 leads to a more compact formulation.  Nonetheless, we begin with named


### PR DESCRIPTION
There was a mixture of using 'De Bruijn' and 'de Bruijn' in Chapter DeBruijn and some other parts of the book, I replaced all of them with 'de Bruijn' except the ones at the beginning of the sentences.