### PR TITLE
[ upgrade ] Agda 2.6.0.1 and (upcoming) stdlib 1.1

### DIFF
--- a/src/plfa/Inference.lagda
+++ b/src/plfa/Inference.lagda
@@ -251,8 +251,7 @@ import Relation.Binary.PropositionalEquality as Eq
 open Eq using (_≡_; refl; sym; trans; cong; cong₂; _≢_)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Nat using (ℕ; zero; suc; _+_)
-open import Data.String using (String)
-open import Data.String.Unsafe using (_≟_)
+open import Data.String using (String; _≟_)
 open import Data.Product using (_×_; ∃; ∃-syntax) renaming (_,_ to ⟨_,_⟩)
 open import Relation.Nullary using (¬_; Dec; yes; no)
 \end{code}

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -53,8 +53,7 @@ four.
 
 \begin{code}
 open import Relation.Binary.PropositionalEquality using (_≡_; _≢_; refl)
-open import Data.String using (String)
-open import Data.String.Unsafe using (_≟_)
+open import Data.String using (String; _≟_)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Relation.Nullary using (Dec; yes; no; ¬_)

--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -22,8 +22,7 @@ sequences for us.
 \begin{code}
 open import Relation.Binary.PropositionalEquality
   using (_≡_; _≢_; refl; sym; cong; cong₂)
-open import Data.String using (String)
-open import Data.String.Unsafe using (_≟_)
+open import Data.String using (String; _≟_)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Data.Product


### PR DESCRIPTION
We were talking about SPLV yesterday and realised it would be nice to have Agda
installed on the machines in the lab for both Phil & Conor's lectures. The sensible
solution seems to synchronise on the latest released version.

The changes needed to upgrade are pretty light. The fact we have managed to get
rid of `Data.String.Unsafe` raises the question of how much of PLFA can be checked
with the `--safe` option turned on.

Note that this PR is not ready yet:

* [ ] Agda stdlib 1.1 has not been released yet (agda/agda-stdlib#808)
* [ ] I have not looked into updating the build system to pick up the new versions

You should be able to push additional commits to the branch to update the build
system before merging.