### PR TITLE
Lambda: expands the BNF abbreviation

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -90,7 +90,7 @@ case terms use naturals). We will see this again when we come
 to the rules for assigning types to terms, where constructors
 correspond to introduction rules and deconstructors to eliminators.
 
-Here is the syntax of terms in BNF:
+Here is the syntax of terms in the Backus-Naur form (BNF):
 
     L, M, N  ::=
       ` x  |  ƛ x ⇒ N  |  L · M  |

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -90,7 +90,7 @@ case terms use naturals). We will see this again when we come
 to the rules for assigning types to terms, where constructors
 correspond to introduction rules and deconstructors to eliminators.
 
-Here is the syntax of terms in the Backus-Naur form (BNF):
+Here is the syntax of terms in Backus-Naur Form (BNF):
 
     L, M, N  ::=
       ` x  |  ƛ x ⇒ N  |  L · M  |


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch expands the BNF abbreviation as that is the first time ever in the book that it is used.