### PR TITLE
Lambda: fixes a prose comparison in the primed exercise

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -212,7 +212,7 @@ definition may use `plusᶜ` as defined earlier (or may not
 
 #### Exercise `primed` (stretch)
 
-Some people find it annoying to write `` ` "x" `` instead of `x`.
+Some people find it annoying to write `` ` "x" `` instead of `"x"`.
 We can make examples with lambda terms slightly easier to write
 by adding the following definitions:
 \begin{code}


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch fixes a comparison in prose of `` ` "x" `` and `"x"` (instead of just `x`). Therefore, the only difference is in the back-tick.