### PR TITLE
Lambda: makes spacing consistent in substitution examples

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -486,10 +486,10 @@ simply push substitution recursively into the subterms.
 Here is confirmation that the examples above are correct:
 
 \begin{code}
-_ : (ƛ "z" ⇒ ` "s" · (` "s" · ` "z")) [ "s" := sucᶜ ] ≡  ƛ "z" ⇒ sucᶜ · (sucᶜ · ` "z")
+_ : (ƛ "z" ⇒ ` "s" · (` "s" · ` "z")) [ "s" := sucᶜ ] ≡ ƛ "z" ⇒ sucᶜ · (sucᶜ · ` "z")
 _ = refl
 
-_ : (sucᶜ · (sucᶜ · ` "z")) [ "z" := `zero ] ≡  sucᶜ · (sucᶜ · `zero)
+_ : (sucᶜ · (sucᶜ · ` "z")) [ "z" := `zero ] ≡ sucᶜ · (sucᶜ · `zero)
 _ = refl
 
 _ : (ƛ "x" ⇒ ` "y") [ "y" := `zero ] ≡ ƛ "x" ⇒ `zero


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch makes spacing consistent around `≡` in substitution examples.