### PR TITLE
Lambda: adds a hyphen in an inference rule such that the line runs ov…

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -544,7 +544,7 @@ the rules for reduction of applications are written as follows:
     L · M —→ L′ · M
 
     M —→ M′
-    -------------- ξ-·₂
+    --------------- ξ-·₂
     V · M —→ V · M′
 
     ----------------------------- β-ƛ


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch extends an inference rule line such that it runs over the whole conclusion.