### PR TITLE
Lambda: removes unused imports

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -57,7 +57,7 @@ open import Data.String using (String)
 open import Data.String.Unsafe using (_≟_)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Empty using (⊥; ⊥-elim)
-open import Relation.Nullary using (yes; no; ¬_)
+open import Relation.Nullary using (Dec; yes; no; ¬_)
 open import Data.List using (List; _∷_; [])
 \end{code}
 

--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -57,8 +57,7 @@ open import Data.String using (String)
 open import Data.String.Unsafe using (_≟_)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Empty using (⊥; ⊥-elim)
-open import Relation.Nullary using (Dec; yes; no; ¬_)
-open import Relation.Nullary.Negation using (¬?)
+open import Relation.Nullary using (yes; no; ¬_)
 open import Data.List using (List; _∷_; [])
 \end{code}
 


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch removes unused imports at the beginning of the chapter.