### PR TITLE
Lambda: removes the mention of Δ as it is never used

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -976,7 +976,7 @@ consider terms with free variables.  To type a term,
 we must first type its subterms, and in particular in the
 body of an abstraction its bound variable may appear free.
 
-A _context_ associates variables with types.  We let `Γ` and `Δ` range
+A _context_ associates variables with types.  We let `Γ` range
 over contexts.  We write `∅` for the empty context, and `Γ , x ⦂ A`
 for the context that extends `Γ` by mapping variable `x` to type `A`.
 For example,


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch removes the mention of `Δ` as a context, as it is never actually used in the chapter.