### PR TITLE
Lambda: aligns an inference rule line

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -1087,7 +1087,7 @@ data _⊢_⦂_ : Context → Term → Type → Set where
   -- Axiom
   ⊢` : ∀ {Γ x A}
     → Γ ∋ x ⦂ A
-       -------------
+      -----------
     → Γ ⊢ ` x ⦂ A
 
   -- ⇒-I


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch aligns a dashed line in the rule for the ``⊢` `` typing judgment such that a premise and the conclusion start in the same column.