### PR TITLE
Lambda: makes a statement about what simply-typed lambda calculus is

### DIFF
--- a/src/plfa/Lambda.lagda
+++ b/src/plfa/Lambda.lagda
@@ -1151,6 +1151,9 @@ the three places where a bound variable is introduced.
 
 The rules are deterministic, in that at most one rule applies to every term.
 
+The syntax, operational semantics and typing rules as given by `Term`,
+`_—→_` and `_⊢_⦂_`, respectively, formalise the simply-typed lambda
+calculus.
 
 ### Checking inequality and postulating the impossible {#impossible}
 


### PR DESCRIPTION
In the introductory on lambda calculus, this patch adds a statement explaining what formalises the simply-typed lambda calculus. In the introduction STLC is said to be formalised in the chapter, but nowhere else is this term used again. This patch fixes the issue.