### PR TITLE
Properties: fixes an explanation of the canonical function

### DIFF
--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -183,7 +183,7 @@ There are only three interesting cases to consider:
 
 The variable case is thrown out because a closed term has no free
 variables and because a variable is not a value.  The cases for
-application, zero, successor, and fixpoint are thrown out because they
+application, case expression, and fixpoint are thrown out because they
 are not values.
 
 Conversely, if a term is canonical then it is a value


### PR DESCRIPTION
In the chapter on properties, this patch fixes an analysis of the `canonical` function. In particular, the analysis used to say that cases for zero and successor are thrown out, which is not true and it contradicts the paragraph preceding it. Instead, the patch fixes that by saying that case expression is thrown out, which wasn't mentioned.