### PR TITLE
Properties: adds a missing pronoun

### DIFF
--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -1200,7 +1200,7 @@ _ = refl
 Again, the derivation in the previous chapter was derived by
 editing the above.
 
-Similarly, can evaluate the corresponding term for Church numerals:
+Similarly, we can evaluate the corresponding term for Church numerals:
 \begin{code}
 _ : eval (gas 100) ⊢2+2ᶜ ≡
   steps


### PR DESCRIPTION
In the chapter on lambda calculus properties, this patch adds a missing pronoun.