### PR TITLE
Simplify progress

### DIFF
--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -268,9 +268,9 @@ progress (⊢suc ⊢M) with progress ⊢M
 ...  | done VM                              =  done (V-suc VM)
 progress (⊢case ⊢L ⊢M ⊢N) with progress ⊢L
 ... | step L—→L′                            =  step (ξ-case L—→L′)
-... | done VL with canonical ⊢L VL
-...   | C-zero                              =  step β-zero
-...   | C-suc CL                            =  step (β-suc (value CL))
+... | done VL with VL
+...   | V-zero                              =  step β-zero
+...   | V-suc VS                            =  step (β-suc VS)
 progress (⊢μ ⊢M)                            =  step β-μ
 \end{code}
 We induct on the evidence that the term is well-typed.

--- a/src/plfa/Properties.lagda
+++ b/src/plfa/Properties.lagda
@@ -264,8 +264,8 @@ progress (⊢L · ⊢M) with progress ⊢L
 ...     | C-ƛ _                             =  step (β-ƛ VM)
 progress ⊢zero                              =  done V-zero
 progress (⊢suc ⊢M) with progress ⊢M
-...  | step M—→M′                           =  step (ξ-suc M—→M′)
-...  | done VM                              =  done (V-suc VM)
+... | step M—→M′                            =  step (ξ-suc M—→M′)
+... | done VM                               =  done (V-suc VM)
 progress (⊢case ⊢L ⊢M ⊢N) with progress ⊢L
 ... | step L—→L′                            =  step (ξ-case L—→L′)
 ... | done VL with VL


### PR DESCRIPTION
This PR contains two patches:

* first slightly simplifies the `progress` function, computing `canonical` and back is not necessary in one case.
* second one is purely visual: aligns `with` cases in the progress function. 