### PR TITLE
Fix DejaVu font name and path

### DIFF
--- a/_sass/agda.scss
+++ b/_sass/agda.scss
@@ -1,8 +1,8 @@
 // Define variables for code formatting
 @font-face {
-    font-family: 'Dejavu Sans Mono';
-    src: url('fonts/DejavuSansMono.woff2') format('woff2'),
-         url('fonts/DejavuSansMono.woff') format('woff');
+    font-family: 'DejaVu Sans Mono';
+    src: url('fonts/DejaVuSansMono.woff2') format('woff2'),
+         url('fonts/DejaVuSansMono.woff') format('woff');
     font-weight: normal;
     font-style: normal;
 
@@ -16,7 +16,7 @@
 }
 
 @mixin code-font {
-    font-family: 'Dejavu Sans Mono', 'Source Code Pro', 'Bitstream Vera Sans Mono', 'FreeMono', 'Courier New', 'Monaco', 'Menlo', monospace, serif;
+    font-family: 'DejaVu Sans Mono', 'Source Code Pro', 'Bitstream Vera Sans Mono', 'FreeMono', 'Courier New', 'Monaco', 'Menlo', monospace, serif;
     font-size: .85em;
 }
 @mixin code-container {


### PR DESCRIPTION
The font name "Dejavu" and it's path should be "DejaVu".

The previous name and it's path "Dejavu" will cause jekyll shows:
`"ERROR '/assets/fonts/DejavuSansMono.woff2' not found"`,
which actually in `/assets/fonts/DejaVuSansMono.woff2`.