### PR TITLE
Lambda: fixes the 'well typed' usage per issue #318

### DIFF
--- a/src/plfa/Lambda.lagda.md
+++ b/src/plfa/Lambda.lagda.md
@@ -1374,7 +1374,7 @@ or explain why there are no such types.
 #### Exercise `mul-type` (recommended)
 
 Using the term `mul` you defined earlier, write out the derivation
-showing that it is well-typed.
+showing that it is well typed.
 
 ```
 -- Your code goes here
@@ -1384,7 +1384,7 @@ showing that it is well-typed.
 #### Exercise `mulᶜ-type`
 
 Using the term `mulᶜ` you defined earlier, write out the derivation
-showing that it is well-typed.
+showing that it is well typed.
 
 ```
 -- Your code goes here


### PR DESCRIPTION
In the introductory chapter on lambda calculus, this patch fixes the usage of "well typed" per issue #318.