### PR TITLE
More: Fixes the usage of 'well typed' per issue #318

### DIFF
--- a/src/plfa/More.lagda.md
+++ b/src/plfa/More.lagda.md
@@ -1225,7 +1225,7 @@ postulate
 ```
 Note the arguments need to be swapped and `W` needs to have
 its context adjusted via renaming in order for the right-hand
-side to be well-typed.
+side to be well typed.
 
 
 ## Unicode


### PR DESCRIPTION
In the chapter on additional constructs of STLC, this one-line patch fixes the usage of "well typed" per issue #318.