### PR TITLE
Inference: fixes the usage of 'ill typed' per issue #318

### DIFF
--- a/src/plfa/Inference.lagda.md
+++ b/src/plfa/Inference.lagda.md
@@ -936,13 +936,13 @@ _ : synthesize ∅ ((ƛ "x" ⇒ ` "y" ↑) ↓ (`ℕ ⇒ `ℕ)) ≡ no _
 _ = refl
 ```
 
-Argument in application is ill-typed:
+Argument in application is ill typed:
 ```
 _ : synthesize ∅ (plus · sucᶜ) ≡ no _
 _ = refl
 ```
 
-Function in application is ill-typed:
+Function in application is ill typed:
 ```
 _ : synthesize ∅ (plus · sucᶜ · two) ≡ no _
 _ = refl


### PR DESCRIPTION
In the chapter on inference, this simple patch fixes the usage of "ill typed" analogous to issue #318.