### PR TITLE
Fixes the usage of 'well-founded' analogous to the issue #318

### DIFF
--- a/src/plfa/Induction.lagda.md
+++ b/src/plfa/Induction.lagda.md
@@ -309,7 +309,7 @@ then `cong f e` is evidence that `f x ≡ f y`, for any function `f`.
 
 Here the inductive hypothesis is not assumed, but instead proved by a
 recursive invocation of the function we are defining, `+-assoc m n p`.
-As with addition, this is well-founded because associativity of
+As with addition, this is well founded because associativity of
 larger numbers is proved in terms of associativity of smaller numbers.
 In this case, `assoc (suc m) n p` is proved using `assoc m n p`.
 The correspondence between proof by induction and definition by


### PR DESCRIPTION
In the same manner as https://github.com/plfa/plfa.github.io/pull/368, in the chapter on induction this patch fixes the usage of "well-founded" analogous to the usage of "well-typed" per issue #318.