### PR TITLE
[ fix ] bug in the last line of Formal vs. Informal

### DIFF
--- a/highlight.sh
+++ b/highlight.sh
@@ -81,7 +81,7 @@ fi
 
 # Create a sed script which matches and replaces all Agda standard library links
 if [ ! -f "$AGDA_STDLIB_SED" ]; then
-    echo "s|\\(Agda\\.[A-Za-z\\.]*\\)|$AGDA_STDLIB_URL\\1|;" > "$AGDA_STDLIB_SED"
+    echo "s|\\(Agda\\.[A-Za-z\\.]+\\)|$AGDA_STDLIB_URL\\1|;" > "$AGDA_STDLIB_SED"
     find "$STDLIB_PATH" -name "*.agda" -print0 | while read -d $'\0' AGDA_MODULE_PATH; do
         AGDA_MODULE=$(eval "echo \"$AGDA_MODULE_PATH\" | sed -e \"s|$STDLIB_PATH/||g; s|/|\\\.|g; s|\.agda|\\\.html|g\"")
         echo "s|$AGDA_MODULE|$AGDA_STDLIB_URL$AGDA_MODULE|g;" >> "$AGDA_STDLIB_SED"


### PR DESCRIPTION
In the last line of https://plfa.github.io/Lambda/#formal-vs-informal
we get a spurious link to the standard library because the script
happily matches "Agda."

Note that I couldn't test this as `make` fails with weird warnings
on my laptop.