### PR TITLE
Properties: adds a sentence on canonical forms

### DIFF
--- a/src/plfa/Properties.lagda.md
+++ b/src/plfa/Properties.lagda.md
@@ -128,6 +128,8 @@ which are the same function with the arguments swapped.
 ## Canonical Forms
 
 Well-typed values must take one of a small number of _canonical forms_.
+A canonical form of a term is the end result of its underlying
+computation.
 We provide an analogue of the `Value` relation that relates values
 to their types.  A lambda expression must have a function type,
 and a zero or successor expression must be a natural.

--- a/src/plfa/Properties.lagda.md
+++ b/src/plfa/Properties.lagda.md
@@ -127,10 +127,8 @@ which are the same function with the arguments swapped.
 
 ## Canonical Forms
 
-Well-typed values must take one of a small number of _canonical forms_.
-A canonical form of a term is the end result of its underlying
-computation.
-We provide an analogue of the `Value` relation that relates values
+Well-typed values must take one of a small number of _canonical forms_,
+which provide an analogue of the `Value` relation that relates values
 to their types.  A lambda expression must have a function type,
 and a zero or successor expression must be a natural.
 Further, the body of a function must be well typed in a context


### PR DESCRIPTION
In the chapter on properties, this patch adds a sentence about canonical forms. I'm not completely sure if it makes a good statement, but with this I at least wanted to start a discussion on what are canonical forms; the prose no where says that at the moment.