### PR TITLE
Changed some implicit arguments

### DIFF
--- a/src/plfa/DeBruijn.lagda.md
+++ b/src/plfa/DeBruijn.lagda.md
@@ -860,7 +860,7 @@ data _—↠_ : ∀ {Γ A} → (Γ ⊢ A) → (Γ ⊢ A) → Set where
       ---------
     → L —↠ N
 
-begin_ : ∀ {Γ} {A} {M N : Γ ⊢ A}
+begin_ : ∀ {Γ A} {M N : Γ ⊢ A}
   → M —↠ N
     ------
   → M —↠ N

--- a/src/plfa/More.lagda.md
+++ b/src/plfa/More.lagda.md
@@ -835,8 +835,8 @@ data Value : ∀ {Γ A} → Γ ⊢ A → Set where
   -- primitives
 
   V-con : ∀ {Γ n}
-      ---------------------
-    → Value {Γ = Γ} (con n)
+      -----------------
+    → Value (con {Γ} n)
 
   -- products
 
@@ -916,8 +916,8 @@ data _—→_ : ∀ {Γ A} → (Γ ⊢ A) → (Γ ⊢ A) → Set where
     → V `* M —→ V `* M′
 
   δ-* : ∀ {Γ c d}
-      -------------------------------------
-    → con {Γ = Γ} c `* con d —→ con (c * d)
+      ---------------------------------
+    → con {Γ} c `* con d —→ con (c * d)
 
   -- let
 
@@ -1001,7 +1001,7 @@ data _—↠_ : ∀ {Γ A} → (Γ ⊢ A) → (Γ ⊢ A) → Set where
       ------
     → L —↠ N
 
-begin_ : ∀ {Γ} {A} {M N : Γ ⊢ A}
+begin_ : ∀ {Γ A} {M N : Γ ⊢ A}
   → M —↠ N
     ------
   → M —↠ N


### PR DESCRIPTION
Combined implicit arguments of `begin_` function, and removed unnecessary implicit argument assigning.
 
For `V-con`, I think the implicit context `Γ` should go after `con` to be consistent with what is happening to `V-zero`, and the explanation of the previous chapter for it:

> Here zero requires an implicit parameter to aid inference, much in the same way that [] did in Lists.

It is also already the case in `δ-*`.