### PR TITLE
Bisimulation: Fixed a sentence

### DIFF
--- a/src/plfa/Bisimulation.lagda.md
+++ b/src/plfa/Bisimulation.lagda.md
@@ -232,7 +232,7 @@ where appropriate (in this case, only for the body of an abstraction).
 ## Simulation commutes with substitution
 
 The third technical result is that simulation commutes with substitution.
-It is more complex than substitution, because where we had one renaming map
+It is more complex than renaming, because where we had one renaming map
 `ρ` here we need two substitution maps, `σ` and `σ†`.
 
 The proof first requires we establish an analogue of extension.


### PR DESCRIPTION
I think substitution meant to be more complex than _renaming_.

Also, there is a sentence regarding extending the environment that says

> in this case, only for the body of an abstraction.

But extending is also needed for `~let`, so I don't know if this sentence needs to change or "an abstraction" means both `~ƛ` and `~let` since `~let` is translated to an abstraction.