### PR TITLE
Add missing library file

### DIFF
--- a/courses/puc/2019/tspl2019.agda-lib
+++ b/courses/puc/2019/tspl2019.agda-lib
@@ -1,0 +1,3 @@
+name: tspl2019
+depend: standard-library plfa
+include: .


### PR DESCRIPTION
Adding this missing file fixes the import issue:
```
The name of the top level module does not match the file name. The
module Assignment1 should be defined in one of the following files:
...
```