### PR TITLE
[WIP] Rewrite usage of impossible using proof-by-reflection

### DIFF
--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -420,10 +420,19 @@ lookup (Γ , _) (suc n)  =  lookup Γ n
 lookup ∅       _        =  ⊥-elim impossible
   where postulate impossible : ⊥
 ```
-We intend to apply the function only when the natural is
-shorter than the length of the context, which we indicate by
-postulating an `impossible` term, just as we did
-[here]({{ site.baseurl }}/Lambda/#impossible).
+We intend to apply the function only when the natural is shorter than the length
+of the context, which we indicate by postulating a term `impossible` of the
+empty type `⊥`.  If we use C-c C-n to normalise the term 
+
+    lookup (∅ , `ℕ ⇒ `ℕ , `ℕ) 3
+
+Agda will return an answer warning us that the impossible has occurred:
+
+    ⊥-elim (plfa.part2.DeBruijn.impossible 1)
+
+While postulating the impossible is a useful technique, it must be
+used with care, since such postulation could allow us to provide
+evidence of _any_ proposition whatsoever, regardless of its truth.
 
 Given the above, we can convert a natural to a corresponding
 de Bruijn index, looking up its type in the context:

--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -1158,33 +1158,6 @@ the three places where a bound variable is introduced.
 The rules are deterministic, in that at most one rule applies to every term.
 
 
-### Checking inequality and postulating the impossible {#impossible}
-
-The following function makes it convenient to assert an inequality:
-```
-_≠_ : ∀ (x y : Id) → x ≢ y
-x ≠ y  with x ≟ y
-...       | no  x≢y  =  x≢y
-...       | yes _    =  ⊥-elim impossible
-  where postulate impossible : ⊥
-```
-Here `_≟_` is the function that tests two identifiers for equality.
-We intend to apply the function only when the
-two arguments are indeed unequal, and indicate that the second
-case should never arise by postulating a term `impossible` of
-the empty type `⊥`.  If we use C-c C-n to normalise the term
-
-    "a" ≠ "a"
-
-Agda will return an answer warning us that the impossible has occurred:
-
-    ⊥-elim (plfa.part2.Lambda.impossible "a" "a" refl)
-
-While postulating the impossible is a useful technique, it must be
-used with care, since such postulation could allow us to provide
-evidence of _any_ proposition whatsoever, regardless of its truth.
-
-
 ### Example type derivations {#derivation}
 
 Type derivations correspond to trees. In informal notation, here
@@ -1221,7 +1194,7 @@ Ch A = (A ⇒ A) ⇒ A ⇒ A
 ⊢twoᶜ : ∀ {Γ A} → Γ ⊢ twoᶜ ⦂ Ch A
 ⊢twoᶜ = ⊢ƛ (⊢ƛ (⊢` ∋s · (⊢` ∋s · ⊢` ∋z)))
   where
-  ∋s = S ("s" ≠ "z") Z
+  ∋s = S (λ()) Z
   ∋z = Z
 ```
 
@@ -1234,11 +1207,11 @@ Here are the typings corresponding to computing two plus two:
 ⊢plus = ⊢μ (⊢ƛ (⊢ƛ (⊢case (⊢` ∋m) (⊢` ∋n)
          (⊢suc (⊢` ∋+ · ⊢` ∋m′ · ⊢` ∋n′)))))
   where
-  ∋+  = (S ("+" ≠ "m") (S ("+" ≠ "n") (S ("+" ≠ "m") Z)))
-  ∋m  = (S ("m" ≠ "n") Z)
+  ∋+  = (S (λ()) (S (λ()) (S (λ()) Z)))
+  ∋m  = (S (λ()) Z)
   ∋n  = Z
   ∋m′ = Z
-  ∋n′ = (S ("n" ≠ "m") Z)
+  ∋n′ = (S (λ()) Z)
 
 ⊢2+2 : ∅ ⊢ plus · two · two ⦂ `ℕ
 ⊢2+2 = ⊢plus · ⊢two · ⊢two
@@ -1257,9 +1230,9 @@ And here are typings for the remainder of the Church example:
 ⊢plusᶜ : ∀ {Γ A} → Γ  ⊢ plusᶜ ⦂ Ch A ⇒ Ch A ⇒ Ch A
 ⊢plusᶜ = ⊢ƛ (⊢ƛ (⊢ƛ (⊢ƛ (⊢` ∋m · ⊢` ∋s · (⊢` ∋n · ⊢` ∋s · ⊢` ∋z)))))
   where
-  ∋m = S ("m" ≠ "z") (S ("m" ≠ "s") (S ("m" ≠ "n") Z))
-  ∋n = S ("n" ≠ "z") (S ("n" ≠ "s") Z)
-  ∋s = S ("s" ≠ "z") Z
+  ∋m = S (λ()) (S (λ()) (S (λ()) Z))
+  ∋n = S (λ()) (S (λ()) Z)
+  ∋s = S (λ()) Z
   ∋z = Z
 
 ⊢sucᶜ : ∀ {Γ} → Γ ⊢ sucᶜ ⦂ `ℕ ⇒ `ℕ

--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -209,40 +209,6 @@ definition may use `plusᶜ` as defined earlier (or may not
 ```
 
 
-#### Exercise `primed` (stretch)
-
-Some people find it annoying to write `` ` "x" `` instead of `x`.
-We can make examples with lambda terms slightly easier to write
-by adding the following definitions:
-```
-ƛ′_⇒_ : Term → Term → Term
-ƛ′ (` x) ⇒ N  =  ƛ x ⇒ N
-ƛ′ _ ⇒ _      =  ⊥-elim impossible
-  where postulate impossible : ⊥
-
-case′_[zero⇒_|suc_⇒_] : Term → Term → Term → Term → Term
-case′ L [zero⇒ M |suc (` x) ⇒ N ]  =  case L [zero⇒ M |suc x ⇒ N ]
-case′ _ [zero⇒ _ |suc _ ⇒ _ ]      =  ⊥-elim impossible
-  where postulate impossible : ⊥
-
-μ′_⇒_ : Term → Term → Term
-μ′ (` x) ⇒ N  =  μ x ⇒ N
-μ′ _ ⇒ _      =  ⊥-elim impossible
-  where postulate impossible : ⊥
-```
-The definition of `plus` can now be written as follows:
-```
-plus′ : Term
-plus′ = μ′ + ⇒ ƛ′ m ⇒ ƛ′ n ⇒
-          case′ m
-            [zero⇒ n
-            |suc m ⇒ `suc (+ · m · n) ]
-  where
-  +  =  ` "+"
-  m  =  ` "m"
-  n  =  ` "n"
-```
-Write out the definition of multiplication in the same style.
 
 
 ### Formal vs informal

--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -58,6 +58,7 @@ open import Data.String using (String; _≟_)
 open import Data.Nat using (ℕ; zero; suc)
 open import Data.Empty using (⊥; ⊥-elim)
 open import Relation.Nullary using (Dec; yes; no; ¬_)
+open import Relation.Nullary.Decidable using (False; toWitnessFalse)
 open import Data.List using (List; _∷_; [])
 ```
 
@@ -1021,10 +1022,13 @@ data _∋_⦂_ : Context → Id → Type → Set where
     → Γ , x ⦂ A ∋ x ⦂ A
 
   S : ∀ {Γ x y A B}
-    → x ≢ y
+    → {x≢y : False (x ≟ y)}
     → Γ ∋ x ⦂ A
       ------------------
     → Γ , y ⦂ B ∋ x ⦂ A
+```
+
+```
 ```
 
 The constructors `Z` and `S` correspond roughly to the constructors
@@ -1160,7 +1164,7 @@ Ch A = (A ⇒ A) ⇒ A ⇒ A
 ⊢twoᶜ : ∀ {Γ A} → Γ ⊢ twoᶜ ⦂ Ch A
 ⊢twoᶜ = ⊢ƛ (⊢ƛ (⊢` ∋s · (⊢` ∋s · ⊢` ∋z)))
   where
-  ∋s = S (λ()) Z
+  ∋s = S Z
   ∋z = Z
 ```
 
@@ -1173,11 +1177,11 @@ Here are the typings corresponding to computing two plus two:
 ⊢plus = ⊢μ (⊢ƛ (⊢ƛ (⊢case (⊢` ∋m) (⊢` ∋n)
          (⊢suc (⊢` ∋+ · ⊢` ∋m′ · ⊢` ∋n′)))))
   where
-  ∋+  = (S (λ()) (S (λ()) (S (λ()) Z)))
-  ∋m  = (S (λ()) Z)
+  ∋+  = S (S (S Z))
+  ∋m  = S Z
   ∋n  = Z
   ∋m′ = Z
-  ∋n′ = (S (λ()) Z)
+  ∋n′ = S Z
 
 ⊢2+2 : ∅ ⊢ plus · two · two ⦂ `ℕ
 ⊢2+2 = ⊢plus · ⊢two · ⊢two
@@ -1196,9 +1200,9 @@ And here are typings for the remainder of the Church example:
 ⊢plusᶜ : ∀ {Γ A} → Γ  ⊢ plusᶜ ⦂ Ch A ⇒ Ch A ⇒ Ch A
 ⊢plusᶜ = ⊢ƛ (⊢ƛ (⊢ƛ (⊢ƛ (⊢` ∋m · ⊢` ∋s · (⊢` ∋n · ⊢` ∋s · ⊢` ∋z)))))
   where
-  ∋m = S (λ()) (S (λ()) (S (λ()) Z))
-  ∋n = S (λ()) (S (λ()) Z)
-  ∋s = S (λ()) Z
+  ∋m = S (S (S Z))
+  ∋n = S (S Z)
+  ∋s = S Z
   ∋z = Z
 
 ⊢sucᶜ : ∀ {Γ} → Γ ⊢ sucᶜ ⦂ `ℕ ⇒ `ℕ
@@ -1260,10 +1264,10 @@ The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
 there is at most one `A` such that the judgment holds:
 ```
 ∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
-∋-injective Z        Z          =  refl
-∋-injective Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
-∋-injective (S x≢ _) Z          =  ⊥-elim (x≢ refl)
-∋-injective (S _ ∋x) (S _ ∋x′)  =  ∋-injective ∋x ∋x′
+∋-injective Z                 Z                  =  refl
+∋-injective Z                 (S {x≢y = x≢x} _)  =  ⊥-elim (toWitnessFalse x≢x refl)
+∋-injective (S {x≢y = x≢x} _) Z                  =  ⊥-elim (toWitnessFalse x≢x refl)
+∋-injective (S ∋x)            (S ∋x′)            =  ∋-injective ∋x ∋x′
 ```
 
 The typing relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`


### PR DESCRIPTION
The purpose of this WIP pull request is to slowly remove all usage of the `impossible` idiom by proof-by-reflection. A new development in Agda has made it possible to do this without using instance search.

- [ ] define `True` and `False` in [Decidable](https://plfa.github.io/Decidable/);
- [ ] explain `toWitnessFalse` and `fromWitnessFalse` in [Decidable](https://plfa.github.io/Decidable/);
- [X] replace `S` constructor in [Lambda](https://plfa.github.io/Lambda/#32455) with a version which checks the inequality implicitly;
