### PR TITLE
inductive data declaration for isomorphism typo

### DIFF
--- a/src/plfa/part1/Isomorphism.lagda.md
+++ b/src/plfa/part1/Isomorphism.lagda.md
@@ -174,10 +174,10 @@ The above is our first use of records. A record declaration is equivalent
 to a corresponding inductive data declaration:
 ```
 data _≃′_ (A B : Set): Set where
-  mk-≃′ : ∀ (to : A → B) →
-          ∀ (from : B → A) →
-          ∀ (from∘to : (∀ (x : A) → from (to x) ≡ x)) →
-          ∀ (to∘from : (∀ (y : B) → to (from y) ≡ y)) →
+  mk-≃′ : ∀ (to′ : A → B) →
+          ∀ (from′ : B → A) →
+          ∀ (from∘to′ : (∀ (x : A) → from′ (to′ x) ≡ x)) →
+          ∀ (to∘from′ : (∀ (y : B) → to′ (from′ y) ≡ y)) →
           A ≃′ B
 
 to′ : ∀ {A B : Set} → (A ≃′ B) → (A → B)


### PR DESCRIPTION
assuming `record _≃_` should be independent from `data _≃′_`, the latter should have primes on all the functions