### PR TITLE
Fix: order of parameter in `split` function.

### DIFF
--- a/src/plfa/part1/Lists.lagda.md
+++ b/src/plfa/part1/Lists.lagda.md
@@ -1076,9 +1076,10 @@ into two lists that merge to give the original list, where all
 elements of one list satisfy the predicate, and all elements of
 the other do not satisfy the predicate.
 
-Define the following variant of the traditional `filter` function on lists,
-which given a decidable predicate and a list returns all elements of the
-list satisfying the predicate:
+Define the following variant of the traditional `filter` function on
+lists, which given a decidable predicate and a list returns a list of
+elements that satisfy the predicate and a list of elements that don't,
+with their corresponding proofs.
 
     split : ∀ {A : Set} {P : A → Set} (P? : Decidable P) (zs : List A)
       → ∃[ xs ] ∃[ ys ] ( merge xs ys zs × All P xs × All (¬_ ∘ P) ys )

--- a/src/plfa/part1/Lists.lagda.md
+++ b/src/plfa/part1/Lists.lagda.md
@@ -1080,8 +1080,8 @@ Define the following variant of the traditional `filter` function on lists,
 which given a decidable predicate and a list returns all elements of the
 list satisfying the predicate:
 
-    split : ∀ {A : Set} {P : A → Set} (P? : Decidable P) (xs : List A)
-      → ∃[ ys ] ∃[ zs ] ( merge xs ys zs × All P ys × All (¬_ ∘ P) zs )
+    split : ∀ {A : Set} {P : A → Set} (P? : Decidable P) (zs : List A)
+      → ∃[ xs ] ∃[ ys ] ( merge xs ys zs × All P xs × All (¬_ ∘ P) ys )
 
 ```
 -- Your code goes here


### PR DESCRIPTION
The `merge` relation can be illustrated as follow:

    merge xs ys zs ≡ xs + ys = zs

This shows a key point: every element of `xs` is contained in `zs`.

The original definition of `split` makes no sense under this revelation.

    split : ∀ {A : Set} {P : A → Set} (P? : Decidable P) (xs : List A)
      → ∃[ ys ] ∃[ zs ] ( merge xs ys zs × All P ys × All (¬_ ∘ P) zs )

`zs` will contain all elements of `xs` (the input!) and we also have that `All (¬_ ∘ P) zs`. This function signature cannot be inhabited, as it would imply that for any `P : A → Set` and any `x : A` we have `¬(P x)`.

This pull request fixes the described issue and modifies the explanation of the `split` exercise a little.