### PR TITLE
Avoid page breaks inside code when printing

### DIFF
--- a/assets/main.scss
+++ b/assets/main.scss
@@ -22,3 +22,7 @@ ul.list-of-contributors {
 ul.list-of-contributors li {
     margin-right: 2rem;
 }
+
+pre {
+    break-inside: avoid;
+}


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/break-inside

This ensures that, when printing a chapter of the book, code will attempt to stay on a single page.