### PR TITLE
Lambda: give the suc constructor is the text with an argument

### DIFF
--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -72,7 +72,7 @@ Terms have seven constructs. Three are for the core lambda calculus:
 Three are for the naturals:
 
   * Zero `` `zero ``
-  * Successor `` `suc N ``
+  * Successor `` `suc M ``
   * Case `` case L [zero⇒ M |suc x ⇒ N ] ``
 
 And one is for recursion:

--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -72,7 +72,7 @@ Terms have seven constructs. Three are for the core lambda calculus:
 Three are for the naturals:
 
   * Zero `` `zero ``
-  * Successor `` `suc ``
+  * Successor `` `suc N ``
   * Case `` case L [zero⇒ M |suc x ⇒ N ] ``
 
 And one is for recursion:


### PR DESCRIPTION
In the chapter on lambda calculus, this simple patch changes how the `suc` constructor is given in the text. A consistent way in the introduction of the chapter would be: `suc` is given an argument, `zero` takes no arguments and `case` takes 4 arguments.