### PR TITLE
Lambda: fix indentation for correct rendering

### DIFF
--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -234,11 +234,11 @@ We intend to apply the function only when the first term is a variable, which we
 indicate by postulating a term `impossible` of the empty type `⊥`.  If we use
 C-c C-n to normalise the term
 
-  ƛ′ two ⇒ two
+    ƛ′ two ⇒ two
 
 Agda will return an answer warning us that the impossible has occurred:
 
-  ⊥-elim (plfa.part2.Lambda.impossible (`` `suc (`suc `zero)) (`suc (`suc `zero)) ``)
+    ⊥-elim (plfa.part2.Lambda.impossible (`` `suc (`suc `zero)) (`suc (`suc `zero)) ``)
 
 While postulating the impossible is a useful technique, it must be
 used with care, since such postulation could allow us to provide


### PR DESCRIPTION
In the chapter on lambda calculus, this simple patch fixes indentation such that the Markdown under consideration is rendered in a box.