### PR TITLE
Lambda: fix the term in an example showing typing relation is not injective

### DIFF
--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -1315,7 +1315,7 @@ there is at most one `A` such that the judgment holds:
 ```
 
 The typing relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`
-the term `ƛ "x" ⇒ "x"` has type `A ⇒ A` for any type `A`.
+the term `` ƛ "x" ⇒ ` "x" `` has type `A ⇒ A` for any type `A`.
 
 ### Non-examples
 


### PR DESCRIPTION
In the chapter on lambda calculus, this patch fixes a term in an example showing that typing relation is not injective by replacing an identifier with a variable.