### PR TITLE
Properties: rename a proof for z ≢ x

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -568,7 +568,7 @@ swap {Γ} {x} {y} {M} {A} {B} {C} x≢y ⊢M = rename ρ ⊢M
       --------------------------
     → Γ , x ⦂ A , y ⦂ B ∋ z ⦂ C
   ρ Z                   =  S x≢y Z
-  ρ (S y≢x Z)           =  Z
+  ρ (S z≢x Z)           =  Z
   ρ (S z≢x (S z≢y ∋z))  =  S z≢y (S z≢x ∋z)
 ```
 Here the renaming map takes a variable at the end into a variable one


### PR DESCRIPTION
In the chapter on properties in the proof of the `swap` lemma, this patch changes the name of a proof of z ≢ x in a case analysis. Namely, given that the sub-lemma `ρ` is about showing that `z` has type `C` in the given context, in the construction of `ρ`:

```agda
  ρ : ∀ {z C}
    → Γ , y ⦂ B , x ⦂ A ∋ z ⦂ C
      --------------------------
    → Γ , x ⦂ A , y ⦂ B ∋ z ⦂ C
  ρ Z                   =  S x≢y Z
  ρ (S y≢x Z)           =  Z
  ρ (S z≢x (S z≢y ∋z))  =  S z≢y (S z≢x ∋z)
```
the second case should instead read:
```agda
  ρ (S z≢x Z)           =  Z
```

Of course, the proof still holds.