### PR TITLE
Properties: fix the inductive hypothesis for lambda abstraction

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -742,8 +742,8 @@ Now that naming is resolved, let's unpack the first three cases:
 
         ∅ ⊢ V ⦂ B
         Γ , x ⦂ A , y ⦂ B ⊢ N ⦂ C
-        ------------------------------------
-        Γ , x ⦂ A , y ⦂ B ⊢ N [ y := V ] ⦂ C
+        ----------------------------
+        Γ , x ⦂ A ⊢ N [ y := V ] ⦂ C
 
     The typing rule for abstractions then yields the required conclusion.
 


### PR DESCRIPTION
In the chapter on Properties, this patch fixes the inductive hypothesis for lambda abstraction in the description of the proof of `subst`.

I might be wrong, but my understanding of the `subst` lemma is that its conclusion has one element fewer in the context than its antecedent.