### PR TITLE
Properties: fix an informal rule in the text for β-ƛ

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -841,8 +841,8 @@ Let's unpack the cases for two of the reduction rules:
 * Rule `β-ƛ`.  We have
 
       Value V
-      ----------------------------
-      (ƛ x ⇒ N) · V ⊢ N [ x := V ]
+      -----------------------------
+      (ƛ x ⇒ N) · V —→ N [ x := V ]
 
   where the left-hand side is typed by
 


### PR DESCRIPTION
In the chapter on properties, this patch fixes an informal rule in the text for `β-ƛ` by using a reduction relation instead of the typing judgment.