### PR TITLE
Properties: introduce an implicit argument M for clarity in the type of M-named variables

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -947,11 +947,11 @@ eval : ∀ {L A}
   → ∅ ⊢ L ⦂ A
     ---------
   → Steps L
-eval {L} (gas zero)    ⊢L                             =  steps (L ∎) out-of-gas
+eval {L} (gas zero)    ⊢L                                =  steps (L ∎) out-of-gas
 eval {L} (gas (suc m)) ⊢L with progress ⊢L
-... | done VL                                         =  steps (L ∎) (done VL)
-... | step L—→M with eval (gas m) (preserve ⊢L L—→M)
-...    | steps M—↠N fin                               =  steps (L —→⟨ L—→M ⟩ M—↠N) fin
+... | done VL                                            =  steps (L ∎) (done VL)
+... | step {M} L—→M with eval (gas m) (preserve ⊢L L—→M)
+...    | steps M—↠N fin                                  =  steps (L —→⟨ L—→M ⟩ M—↠N) fin
 ```
 Let `L` be the name of the term we are reducing, and `⊢L` be the
 evidence that `L` is well typed.  We consider the amount of gas


### PR DESCRIPTION
In the chapter on properties, this simple patch introduces an implicit argument `M` for clarity in the type of M-named variables in the proof of `eval`. The patch makes the proof more pedagogical and easier to write with Agda's interactive type-driven development.

Without the patch, the types of variables are confusing, e.g., the variable `M—↠N` has type `N —↠ N₁`. For the following code with a hole:

```agda
eval : ∀ {L A}
  → Gas
  → ∅ ⊢ L ⦂ A
    ---------
  → Steps L
eval {L} (gas zero)    ⊢L                              =  steps (L ∎) out-of-gas
eval {L} (gas (suc m)) ⊢L with progress ⊢L
... | done VL                                          =  steps (L ∎) (done VL)
... | step L—→M with eval (gas m) (preserve ⊢L L—→M)
...    | steps M—↠N fin                                =  {!!}
```

the goal and context are:

```
Goal: Steps L
————————————————————————————————————————————————————————————
fin  : Finished N₁
M—↠N : N —↠ N₁
N₁   : Term  (not in scope)
m    : ℕ
L—→M : L —→ N
N    : Term  (not in scope)
⊢L   : ∅ ⊢ L ⦂ A
A    : Type  (not in scope)
L    : Term
```

When the patch is applied, the context changes such that the variables with "M" in their names also have M in the corresponding place in their types:

```
Goal: Steps L
————————————————————————————————————————————————————————————
fin  : Finished N
M—↠N : M —↠ N
N    : Term  (not in scope)
m    : ℕ
L—→M : L —→ M
M    : Term
⊢L   : ∅ ⊢ L ⦂ A
A    : Type  (not in scope)
L    : Term
```
