### PR TITLE
Properties: fix the implementation of eval

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -931,27 +931,27 @@ Given a term `L` of type `A`, the evaluator will, for some `N`, return
 a reduction sequence from `L` to `N` and an indication of whether
 reduction finished:
 ```
-data Steps (L : Term) : Set where
+data Steps {L A} : ∅ ⊢ L ⦂ A → Set where
 
-  steps : ∀ {N}
+  steps : ∀ {N} {⊢N : ∅ ⊢ N ⦂ A} {⊢L : ∅ ⊢ L ⦂ A}
     → L —↠ N
     → Finished N
       ----------
-    → Steps L
+    → Steps ⊢L
 ```
 The evaluator takes gas and evidence that a term is well typed,
 and returns the corresponding steps:
 ```
 eval : ∀ {L A}
   → Gas
-  → ∅ ⊢ L ⦂ A
-    ---------
-  → Steps L
-eval {L} (gas zero)    ⊢L                             =  steps (L ∎) out-of-gas
+  → (⊢L : ∅ ⊢ L ⦂ A)
+    ----------------
+  → Steps ⊢L
+eval {L} (gas zero)    ⊢L                                 =  steps (L ∎) out-of-gas
 eval {L} (gas (suc m)) ⊢L with progress ⊢L
-... | done VL                                         =  steps (L ∎) (done VL)
-... | step L—→M with eval (gas m) (preserve ⊢L L—→M)
-...    | steps M—↠N fin                               =  steps (L —→⟨ L—→M ⟩ M—↠N) fin
+... | done VL                                             =  steps (L ∎) (done VL)
+... | step {M} L—→M with eval (gas m) (preserve ⊢L L—→M)
+...    | steps M—↠N fin                                   =  steps (L —→⟨ L—→M ⟩ M—↠N) fin
 ```
 Let `L` be the name of the term we are reducing, and `⊢L` be the
 evidence that `L` is well typed.  We consider the amount of gas


### PR DESCRIPTION
In accordance with issue #455, in the chapter on properties this patch fixes the theorem and the proof for `eval`. I made the changes as small as possible.

I used the `⊢L` name in the type constructor `Steps`, although the next chapter simply says "Steps L" instead of `Steps ⊢L` (though in my opinion the latter would be more appropriate).

The implicit variable `M` is there per https://github.com/plfa/plfa.github.io/pull/454#pullrequestreview-348936479. I kept it implicit because making it explicit would require a change in the definition of the `Progress` type constructor and in all usage sites too.

Your feedback would be highly appreciated.