### PR TITLE
Lambda: Change a confusing sentence

### DIFF
--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -719,7 +719,7 @@ begin M—↠N = M—↠N
 ```
 We can read this as follows:
 
-* From term `M`, we can take no steps, giving a step of type `M —↠ M`.
+* From term `M`, we can take no steps, giving the type `M —↠ M`.
   It is written `M ∎`.
 
 * From term `L` we can take a single step of type `L —→ M` followed by zero


### PR DESCRIPTION
When discussing the reflexive transitive closure, the base case of reflexivity takes 0 steps. It's confusing to call it "a step".