### PR TITLE
proposed text addition: pragmatic note on matching against decidable equality

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -775,7 +775,7 @@ Where the construct introduces a bound variable we need to compare it
 with the substituted variable, applying the drop lemma if they are
 equal and the swap lemma if they are distinct.
 
-Note that for Agda it makes a difference whether we write `x ≟ y` or 
+For Agda it makes a difference whether we write `x ≟ y` or 
 `y ≟ x`. In an interactive proof, Agda will show which residual `with`
 clauses in the definition of `_[_:=_]` need to be simplified, and the
 `with` clauses in `subst` need to match these exactly. The guideline is

--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -775,6 +775,14 @@ Where the construct introduces a bound variable we need to compare it
 with the substituted variable, applying the drop lemma if they are
 equal and the swap lemma if they are distinct.
 
+Testing variable names for equality using the `_≟_` operator has a
+catch. For Agda it makes a difference whether we write `x ≟ y` or 
+`y ≟ x`. If the test matches the constraint that Agda expects, then the
+proof goes through as demonstrated. Otherwise, Agda produces a message
+that reveals the low-level implementation of string equality. To avoid
+this problem, the guideline is to always match literally on the expression
+on which Agda's evaluation is currently stuck.
+
 #### Exercise `subst′` (stretch)
 
 Rewrite `subst` to work with the modified definition `_[_:=_]′`

--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -775,13 +775,13 @@ Where the construct introduces a bound variable we need to compare it
 with the substituted variable, applying the drop lemma if they are
 equal and the swap lemma if they are distinct.
 
-Testing variable names for equality using the `_≟_` operator has a
-catch. For Agda it makes a difference whether we write `x ≟ y` or 
-`y ≟ x`. If the test matches the constraint that Agda expects, then the
-proof goes through as demonstrated. Otherwise, Agda produces a message
-that reveals the low-level implementation of string equality. To avoid
-this problem, the guideline is to always match literally on the expression
-on which Agda's evaluation is currently stuck.
+Note that for Agda it makes a difference whether we write `x ≟ y` or 
+`y ≟ x`. In an interactive proof, Agda will show which residual `with`
+clauses in the definition of `_[_:=_]` need to be simplified, and the
+`with` clauses in `subst` need to match these exactly. The guideline is
+that Agda knows nothing about symmetry or commutativity, which require
+invoking appropriate lemmas, so it is important to think about order of
+arguments and to be consistent.
 
 #### Exercise `subst′` (stretch)
 

--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -942,6 +942,7 @@ data Steps (L : Term) : Set where
 The evaluator takes gas and evidence that a term is well typed,
 and returns the corresponding steps:
 ```
+{-# TERMINATING #-}
 eval : ∀ {L A}
   → Gas
   → ∅ ⊢ L ⦂ A


### PR DESCRIPTION
The first formalization of the lambda using strings for variables has at least one pretty subtle point, which I probably overlooked in the text. For example, it matters a lot whether you write  y ≟ x or  x ≟ y. In one case, the proofs go through nicely, but in the other case Agda dumps a screenful of messages from the low level implementation of string comparison on you. 