### PR TITLE
Properties: fix the rendering of a highlighted expression

### DIFF
--- a/src/plfa/part2/Properties.lagda.md
+++ b/src/plfa/part2/Properties.lagda.md
@@ -74,8 +74,8 @@ other term will itself be closed and well typed.  Repeat.  We will
 either loop forever, in which case evaluation does not terminate, or
 we will eventually reach a value, which is guaranteed to be closed and
 of the same type as the original term.  We will turn this recipe into
-Agda code that can compute for us the reduction sequence of `plus ·
-two · two`, and its Church numeral variant.
+Agda code that can compute for us the reduction sequence of `plus · two · two`,
+and its Church numeral variant.
 
 (The development in this chapter was inspired by the corresponding
 development in _Software Foundations_, Volume _Programming Language


### PR DESCRIPTION
In the chapter on properties, this tiny patch fixes the rendering of a highlighted expression `plus ·
two · two` by removing a line break in the expression. The current broken rendering can be seen in the attached screenshot.

![properties-plus-two-two](https://user-images.githubusercontent.com/6256391/83952527-bb779500-a839-11ea-98ee-4cdc4d2d7cc3.png)
