### PR TITLE
Fix remaining epubcheck warnings

### DIFF
--- a/src/plfa/dedication.md
+++ b/src/plfa/dedication.md
@@ -6,8 +6,17 @@ next      : /Preface/
 ---
 
 <p style="text-align:center;">
-  <p style="font-size:1.5em">de Philip, para Wanda</p>
-  <p style="font-size:1.17em">amor da minha vida</p>
-  <p style="font-size:1em">knock knock knock</p>
-  <p style="font-size:1em">...</p>
+  <span style="font-size:1.5em">de Philip, para Wanda</span>
+</p>
+
+<p style="text-align:center;">
+  <span style="font-size:1.17em">amor da minha vida</span>
+</p>
+
+<p style="text-align:center;">
+  <span style="font-size:1em">knock knock knock</span>
+</p>
+
+<p style="text-align:center;">
+  <span style="font-size:1em">...</span>
 </p>


### PR DESCRIPTION
With this PR and #484, epubcheck gives no more warnings.

HTML does not permit nested `<p>` elements, which epubcheck complains
about. This change fixes those remaining warnings.

This change also causes the Dedication on the website to be centered
when viewed in Safari, which it was not before. Other than that, the Dedication
looks the same in the EPUB and website version.

Closes #480.