### PR TITLE
Align type definitions in even and odd example

### DIFF
--- a/src/plfa/part1/Relations.lagda.md
+++ b/src/plfa/part1/Relations.lagda.md
@@ -661,7 +661,7 @@ data even where
 
 data odd where
 
-  suc   : ∀ {n : ℕ}
+  suc  : ∀ {n : ℕ}
     → even n
       -----------
     → odd (suc n)


### PR DESCRIPTION
While working through the `Relations` chapter I noticed that the type of `odd`'s `suc` constructor didn't line up with the types of the two `even` constructors, so I thought I'd submit a pedantic single-character-diff pull-request. 😅 