### PR TITLE
remove sentence calling proofs of negations proofs by contradiction

### DIFF
--- a/src/plfa/part1/Negation.lagda.md
+++ b/src/plfa/part1/Negation.lagda.md
@@ -34,8 +34,6 @@ as implication of false:
 ¬_ : Set → Set
 ¬ A = A → ⊥
 ```
-This is a form of _proof by contradiction_: if assuming `A` leads
-to the conclusion `⊥` (a contradiction), then we must have `¬ A`.
 
 Evidence that `¬ A` holds is of the form
 


### PR DESCRIPTION
A minor thing, but the negation chapter calls _proofs of negations_ (assume `A`, derive `⊥`, hence `¬ A`) instead _proofs by contradiction_ (assume `¬ A`, derive `⊥`, hence `A`).

See eg [Andrej Bauer](http://math.andrej.com/2010/03/29/proof-of-negation-and-proof-by-contradiction/) arguing that one shouldn't conflate these two principles.

I couldn't think of a better fix than to simply remove the sentence, but I think the flow of the text still makes sense.