### PR TITLE
Fix newline rendering in Quantifiers chapter

### DIFF
--- a/src/plfa/part1/Quantifiers.lagda.md
+++ b/src/plfa/part1/Quantifiers.lagda.md
@@ -51,8 +51,8 @@ Evidence that `∀ (x : A) → B x` holds is of the form
 
 where `N x` is a term of type `B x`, and `N x` and `B x` both contain
 a free variable `x` of type `A`.  Given a term `L` providing evidence
-that `∀ (x : A) → B x` holds, and a term `M` of type `A`, the term `L
-M` provides evidence that `B M` holds.  In other words, evidence that
+that `∀ (x : A) → B x` holds, and a term `M` of type `A`, the term `L M`
+provides evidence that `B M` holds.  In other words, evidence that
 `∀ (x : A) → B x` holds is a function that converts a term `M` of type
 `A` into evidence that `B M` holds.
 


### PR DESCRIPTION
This PR fixes a small layout issue in the Quantifiers chapter. There was a newline in the middle of a code span, which caused the code to render like this: 

![Before](https://user-images.githubusercontent.com/13350302/88540021-95d56380-d012-11ea-9204-df98a8b49982.png)

By moving the newline out of the code span, it now renders like this, which I presume was the intention:

![After](https://user-images.githubusercontent.com/13350302/88540028-98d05400-d012-11ea-841d-4b2dc42b6d21.png)

(I think this is a quirk of Kramdown specifically, as Github Markdown renders this sort of situation `like
this`.)