### PR TITLE
DeBruijn: introduce a version of #_ that depends on no postulate

### DIFF
--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -1376,7 +1376,7 @@ number of lines of code is as follows:
 
     Lambda                      216
     Properties                  235
-    DeBruijn                    275
+    DeBruijn                    276
 
 The relation between the two approaches approximates the
 golden ratio: extrinsically-typed terms

--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -454,7 +454,7 @@ We can then introduce a convenient abbreviation for variables:
 The type of function `#_` asks for clarification. The function takes
 an implicit argument `n<?length` that signals if there is evidence for
 `n` to be within the context's bounds. Both `True` and `_≤?_` are
-defined in Chapter [Decidable]({{ site.baseurl }}/Decidable/. The type
+defined in Chapter [Decidable]({{ site.baseurl }}/Decidable/). The type
 of `n<?length` guards against invoking `#_` on an `n` that is out of
 context bounds. Finally, in the return type `n<?length` is converted
 to a witness that `n` is within the bounds.

--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -451,9 +451,8 @@ We can then introduce a convenient abbreviation for variables:
    → Γ ⊢ lookup (toWitness n<?length)
 #_ n {n<?length}  =  ` count (toWitness n<?length)
 ```
-The type of function `#_` asks for clarification. Function `#_` takes
-an implicit argument `n<?length` that provides evidence for `n` to be
-within the context's bounds. Recall that
+Function `#_` takes an implicit argument `n<?length` that provides
+evidence for `n` to be within the context's bounds. Recall that
 [`True`]({{ site.baseurl }}/Decidable/#proof-by-reflection),
 [`_≤?_`]({{ site.baseurl }}/Decidable/#the-best-of-both-worlds) and
 [`toWitness`]({{ site.baseurl }}/Decidable/#decidables-from-booleans-and-booleans-from-decidables)

--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -451,13 +451,16 @@ We can then introduce a convenient abbreviation for variables:
    → Γ ⊢ lookup (toWitness n<?length)
 #_ n {n<?length}  =  ` count (toWitness n<?length)
 ```
-The type of function `#_` asks for clarification. The function takes
-an implicit argument `n<?length` that signals if there is evidence for
-`n` to be within the context's bounds. Both `True` and `_≤?_` are
-defined in Chapter [Decidable]({{ site.baseurl }}/Decidable/). The type
-of `n<?length` guards against invoking `#_` on an `n` that is out of
-context bounds. Finally, in the return type `n<?length` is converted
-to a witness that `n` is within the bounds.
+The type of function `#_` asks for clarification. Function `#_` takes
+an implicit argument `n<?length` that provides evidence for `n` to be
+within the context's bounds. Recall that
+[`True`]({{ site.baseurl }}/Decidable/#proof-by-reflection),
+[`_≤?_`]({{ site.baseurl }}/Decidable/#the-best-of-both-worlds) and
+[`toWitness`]({{ site.baseurl }}/Decidable/#decidables-from-booleans-and-booleans-from-decidables)
+are defined in Chapter [Decidable]({{ site.baseurl }}/Decidable/). The
+type of `n<?length` guards against invoking `#_` on an `n` that is out
+of context bounds. Finally, in the return type `n<?length` is
+converted to a witness that `n` is within the bounds.
 
 With this abbreviation, we can rewrite the Church numeral two more compactly:
 ```


### PR DESCRIPTION
Per the discussion in issue #513, this patch introduces a formalisation of variables based on de Bruijn indices that relies on no postulates. The accompanying text is updated accordingly.