### PR TITLE
DeBruijn: Adds a conjunction for easier reading

### DIFF
--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -510,7 +510,7 @@ DeBruijn representation.
 Renaming is a necessary prelude to substitution, enabling us
 to "rebase" a term from one context to another.  It
 corresponds directly to the renaming result from the previous
-chapter, but here the theorem that ensures renaming preserves
+chapter, but here the theorem that ensures that renaming preserves
 typing also acts as code that performs renaming.
 
 As before, we first need an extension lemma that allows us to


### PR DESCRIPTION
In the chapter on intrinsically-typed variables in section on renaming, this pull request adds a conjunction for easier reading, i.e., parsing of a sentence. Without it, it took me several consecutive readings of the sentence to get its meaning. Needless to say, the sentence is fine just the way it is, but I'd argue it is much easier to read it when a `that` is added as in this patch.
