### PR TITLE
De Bruijn: changes the indentation of function arguments for consistency

### DIFF
--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -692,10 +692,10 @@ variables it is easy to define the special case of
 substitution for one free variable:
 ```
 _[_] : ∀ {Γ A B}
-        → Γ , B ⊢ A
-        → Γ ⊢ B
-          ---------
-        → Γ ⊢ A
+  → Γ , B ⊢ A
+  → Γ ⊢ B
+    ---------
+  → Γ ⊢ A
 _[_] {Γ} {A} {B} N M =  subst {Γ , B} {Γ} σ {A} N
   where
   σ : ∀ {A} → Γ , B ∋ A → Γ ⊢ A


### PR DESCRIPTION
In the chapter on de Bruijn indices, this simple patch changes the indentation of function arguments to match indentation present throughout the book: two spaces from the beginning of the line before an arrow.