### PR TITLE
De Bruijn: fix a line-break in the middle of a markup

### DIFF
--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -736,8 +736,8 @@ variable to avoid capture:
   `` ƛ "z" ⇒ ` "z" · (` "x" · `zero) ``
 
 Say the bound `"x"` has type `` `ℕ ⇒ `ℕ ``, the substituted
-`"y"` has type `` `ℕ ``, and the free `"x"` also has type ``
-`ℕ ⇒ `ℕ ``.  Here is the example formalised:
+`"y"` has type `` `ℕ ``, and the free `"x"` also has type `` `ℕ ⇒ `ℕ ``.
+Here is the example formalised:
 ```
 M₅ : ∅ , `ℕ ⇒ `ℕ , `ℕ ⊢ (`ℕ ⇒ `ℕ) ⇒ `ℕ
 M₅ = ƛ # 0 · # 1


### PR DESCRIPTION
Currently, in the de Bruijn chapter there is a line-break in the middle of a markup, which results in a weird rendering, as below. This patch fixes that.

![markup-line-break](https://user-images.githubusercontent.com/6256391/95097597-f0cfb900-072d-11eb-915f-4606b48f09bf.png)
