### PR TITLE
De Bruijn: makes type A a parameter to the Steps data type

### DIFF
--- a/src/plfa/part2/DeBruijn.lagda.md
+++ b/src/plfa/part2/DeBruijn.lagda.md
@@ -1066,9 +1066,9 @@ Given a term `L` of type `A`, the evaluator will, for some `N`, return
 a reduction sequence from `L` to `N` and an indication of whether
 reduction finished:
 ```
-data Steps : ∀ {A} → ∅ ⊢ A → Set where
+data Steps {A} : ∅ ⊢ A → Set where
 
-  steps : ∀ {A} {L N : ∅ ⊢ A}
+  steps : {L N : ∅ ⊢ A}
     → L —↠ N
     → Finished N
       ----------


### PR DESCRIPTION
In the chapter on de Bruijn indices, this patch changes the `Steps` data type such that type `A` is its parameter instead of index. This makes it unnecessary to quantify over `A` in the data constructor `steps`, even more so because both `L` and `N` are of type `∅ ⊢ A`. In other words, no need to unify two `A`s because they are the same anyway.