### PR TITLE
More: fixes an informal definition of swap×

### DIFF
--- a/src/plfa/part2/More.lagda.md
+++ b/src/plfa/part2/More.lagda.md
@@ -206,7 +206,7 @@ construct to a calculus without the construct.
 Here is a function to swap the components of a pair:
 
     swap× : ∅ ⊢ A `× B ⇒ B `× A
-    swap× = ƛ z ⇒ `⟨ proj₂ z , proj₁ z ⟩
+    swap× = ƛ z ⇒ `⟨ `proj₂ z , `proj₁ z ⟩
 
 
 ## Alternative formulation of products


### PR DESCRIPTION
A disadvantage of informal presentation is that it doesn't get type-checked by Agda, and this allowed the definition of `swap×` to refer to undefined projection functions. This patch fixes the error in the definition.