### PR TITLE
More: fixes the syntax of substitution in a wrong translation of case×

### DIFF
--- a/src/plfa/part2/More.lagda.md
+++ b/src/plfa/part2/More.lagda.md
@@ -271,14 +271,14 @@ One might think that we could instead use a more compact translation:
     -- WRONG
       (case× L [⟨ x , y ⟩⇒ N ]) †
     =
-      (N †) [ x := proj₁ (L †) ] [ y := proj₂ (L †) ]
+      (N †) [ x := `proj₁ (L †) ] [ y := `proj₂ (L †) ]
 
 But this behaves differently.  The first term always reduces `L`
-before `N`, and it computes `proj₁` and `proj₂` exactly once.  The
+before `N`, and it computes ```proj₁`` and ```proj₂`` exactly once.  The
 second term does not reduce `L` to a value before reducing `N`, and
 depending on how many times and where `x` and `y` appear in `N`, it
-may reduce `L` many times or not at all, and it may compute `proj₁`
-and `proj₂` many times or not at all.
+may reduce `L` many times or not at all, and it may compute ```proj₁``
+and ```proj₂`` many times or not at all.
 
 We can also translate back the other way:
 

--- a/src/plfa/part2/More.lagda.md
+++ b/src/plfa/part2/More.lagda.md
@@ -271,7 +271,7 @@ One might think that we could instead use a more compact translation:
     -- WRONG
       (case× L [⟨ x , y ⟩⇒ N ]) †
     =
-      (N †) [ x := proj₁ (L †) ][ y := proj₂ (L †) ]
+      (N †) [ x := proj₁ (L †) ] [ y := proj₂ (L †) ]
 
 But this behaves differently.  The first term always reduces `L`
 before `N`, and it computes `proj₁` and `proj₂` exactly once.  The


### PR DESCRIPTION
In the chapter on additional constructs of a lambda calculus, this patch fixes the syntax of substitution in an informal intentionally wrong translation of `case×` by adding a whitespace between consecutive square brackets. It also fixes the names of projection functions so they refer to the development earlier in the chapter.