### PR TITLE
More: Fixes the Projection Function Used in the Informal Definition of from×⊤

### DIFF
--- a/src/plfa/part2/More.lagda.md
+++ b/src/plfa/part2/More.lagda.md
@@ -381,7 +381,7 @@ Here is the isomorphism between `A` and ``A `× `⊤``:
     to×⊤ = ƛ x ⇒ `⟨ x , `tt ⟩
 
     from×⊤ : ∅ ⊢ A `× `⊤ ⇒ A
-    from×⊤ = ƛ z ⇒ proj₁ z
+    from×⊤ = ƛ z ⇒ `proj₁ z
 
 
 ## Alternative formulation of unit type


### PR DESCRIPTION
In the chapter on more constructs in a lambda calculus, this patch fixes a reference to a projection function such that it refers to the one defined in the chapter rather than to a non-imported Agda projection function.