### PR TITLE
Fix a tiny rendering bug due to a \n in inline code

### DIFF
--- a/src/plfa/part1/Relations.lagda.md
+++ b/src/plfa/part1/Relations.lagda.md
@@ -334,8 +334,8 @@ using holes and the `C-c C-c`, `C-c C-,`, and `C-c C-r` commands.
 ## Anti-symmetry
 
 The third property to prove about comparison is that it is
-antisymmetric: for all naturals `m` and `n`, if both `m ≤ n` and `n ≤
-m` hold, then `m ≡ n` holds:
+antisymmetric: for all naturals `m` and `n`, if both `m ≤ n` and
+`n ≤ m` hold, then `m ≡ n` holds:
 ```
 ≤-antisym : ∀ {m n : ℕ}
   → m ≤ n


### PR DESCRIPTION
Just stumbled upon this very minor thing when reading PLFA:
![Screenshot_20201020_191309](https://user-images.githubusercontent.com/51103/96657715-89f2f800-1308-11eb-80dd-8fcc00b6e11b.png)
