### PR TITLE
More: Makes A a Parameter to the Steps Data Type

### DIFF
--- a/src/plfa/part2/More.lagda.md
+++ b/src/plfa/part2/More.lagda.md
@@ -1105,9 +1105,9 @@ data Finished {Γ A} (N : Γ ⊢ A) : Set where
        ----------
        Finished N
 
-data Steps : ∀ {A} → ∅ ⊢ A → Set where
+data Steps {A} : ∅ ⊢ A → Set where
 
-  steps : ∀ {A} {L N : ∅ ⊢ A}
+  steps : {L N : ∅ ⊢ A}
     → L —↠ N
     → Finished N
       ----------


### PR DESCRIPTION
In the chapter on a lambda calculus with additional constructs, this patch makes `A` a parameter rather than an index to the `Steps` data type. This is exactly the same as PR #528 for Chapter DeBruijn. 