### PR TITLE
More: Align the Names of Parameters to #_ to Those in Chapter DeBruijn

### DIFF
--- a/src/plfa/part2/More.lagda.md
+++ b/src/plfa/part2/More.lagda.md
@@ -733,10 +733,10 @@ count {Γ , _} {(suc n)} (s≤s p)    =  S (count p)
 
 #_ : ∀ {Γ}
   → (n : ℕ)
-  → {n<?length : True (suc n ≤? length Γ)}
-    --------------------------------------
-  → Γ ⊢ lookup (toWitness n<?length)
-#_ n {n<?length}  =  ` count (toWitness n<?length)
+  → {n∈Γ : True (suc n ≤? length Γ)}
+    --------------------------------
+  → Γ ⊢ lookup (toWitness n∈Γ)
+#_ n {n∈Γ}  =  ` count (toWitness n∈Γ)
 ```
 
 ## Renaming


### PR DESCRIPTION
In the chapter on a lambda calculus with additional constructs, this patch aligns the names of parameters to `#_` to those in `#_` in Chapter DeBruijn.