### PR TITLE
Use https instead of git for fetching the standard library

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "standard-library"]
 	path = standard-library
-	url = git@github.com:agda/agda-stdlib.git
+	url = https://github.com/agda/agda-stdlib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "standard-library"]
 	path = standard-library
 	url = https://github.com/agda/agda-stdlib.git
+	shallow = true


### PR DESCRIPTION
The original git address unnecessarily requires the user to have a GitHub account with SSH.

Also only clone the submodule shallowly.