### PR TITLE
Fix weird tex issue when building PDF

### DIFF
--- a/book/pdf.tex
+++ b/book/pdf.tex
@@ -5,7 +5,7 @@
 \usepackage{fontspec}
 \setmainfont{DejaVu Sans}
 \setsansfont{DejaVu Sans}
-\setmonofont{[DejaVu-mononoki-Symbola-Droid.ttf]}
+\setmonofont{DejaVu-mononoki-Symbola-Droid.ttf}
 \usepackage{soul}
 \usepackage{tcolorbox}
 \tcbuselibrary{skins,breakable}
@@ -36,6 +36,7 @@
 % The following code does not work well for long text as the
 % text will exceed the page boundary.
 \definecolor{background-color}{HTML}{EEEEFF}
+\definecolor{BACKGROUND-COLOR}{HTML}{EEEEFF}
 \let\oldtexttt\texttt%
 \renewcommand{\texttt}[1]{\colorbox{background-color}{\oldtexttt{#1}}}
 


### PR DESCRIPTION
This commit fixes the weird font issues when compiling PLFA as a PDF
under Linux (TeXLive 2017/2019, with Ubuntu 18.04/20.04 LTS).

The exact reason why the changes fixes the compilation is unknown, but
I've tested the change under Linux and macOS, it seems to work.