### PR TITLE
Recover + from |.

### DIFF
--- a/courses/tspl/2019/Assignment1.lagda.md
+++ b/courses/tspl/2019/Assignment1.lagda.md
@@ -142,7 +142,7 @@ Give an example of an operator that has an identity and is
 associative but is not commutative.
 
 
-#### Exercise `finite-|-assoc` (stretch) {#finite-plus-assoc}
+#### Exercise `finite-+-assoc` (stretch) {#finite-plus-assoc}
 
 Write out what is known about associativity of addition on each of the first four
 days using a finite story of creation, as
@@ -196,7 +196,7 @@ Show
 
 for all naturals `n`. Did your proof require induction?
 
-#### Exercise `∸-|-assoc` (practice) {#monus-plus-assoc}
+#### Exercise `∸-+-assoc` (practice) {#monus-plus-assoc}
 
 Show that monus associates with addition, that is,
 

--- a/courses/tspl/2019/Assignment2.lagda.md
+++ b/courses/tspl/2019/Assignment2.lagda.md
@@ -374,7 +374,7 @@ restated in this way.
 -- Your code goes here
 ```
 
-#### Exercise `∃-|-≤` (practice)
+#### Exercise `∃-+-≤` (practice)
 
 Show that `y ≤ z` holds if and only if there exists a `x` such that
 `x + y ≡ z`.

--- a/src/plfa/part1/Induction.lagda.md
+++ b/src/plfa/part1/Induction.lagda.md
@@ -695,7 +695,7 @@ judgments where the first number is less than _m_.
 There is also a completely finite approach to generating the same equations,
 which is left as an exercise for the reader.
 
-#### Exercise `finite-|-assoc` (stretch) {#finite-plus-assoc}
+#### Exercise `finite-+-assoc` (stretch) {#finite-plus-assoc}
 
 Write out what is known about associativity of addition on each of the
 first four days using a finite story of creation, as
@@ -925,7 +925,7 @@ for all naturals `n`. Did your proof require induction?
 ```
 
 
-#### Exercise `∸-|-assoc` (practice) {#monus-plus-assoc}
+#### Exercise `∸-+-assoc` (practice) {#monus-plus-assoc}
 
 Show that monus associates with addition, that is,
 
@@ -942,7 +942,7 @@ for all naturals `m`, `n`, and `p`.
 
 Show the following three laws
 
-     m ^ (n + p) ≡ (m ^ n) * (m ^ p)  (^-distribˡ-|-*)
+     m ^ (n + p) ≡ (m ^ n) * (m ^ p)  (^-distribˡ-+-*)
      (m * n) ^ p ≡ (m ^ p) * (n ^ p)  (^-distribʳ-*)
      (m ^ n) ^ p ≡ m ^ (n * p)        (^-*-assoc)
 

--- a/src/plfa/part1/Quantifiers.lagda.md
+++ b/src/plfa/part1/Quantifiers.lagda.md
@@ -380,7 +380,7 @@ restated in this way.
 -- Your code goes here
 ```
 
-#### Exercise `∃-|-≤` (practice)
+#### Exercise `∃-+-≤` (practice)
 
 Show that `y ≤ z` holds if and only if there exists a `x` such that
 `x + y ≡ z`.


### PR DESCRIPTION
I believe many `-|-` should have been `-+-`.