### PR TITLE
Injectivity of context lookup is functionality

### DIFF
--- a/extra/EvalContexts/Lambda.lagda.md
+++ b/extra/EvalContexts/Lambda.lagda.md
@@ -1336,19 +1336,19 @@ Chapter [Inference](/Inference/)
 will show how to use Agda to compute type derivations directly.
 
 
-### Lookup is injective
+### Lookup is functional
 
-The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
+The lookup relation `Γ ∋ x ⦂ A` is functional, in that for each `Γ` and `x`
 there is at most one `A` such that the judgment holds:
 ```
-∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
-∋-injective Z        Z          =  refl
-∋-injective Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
-∋-injective (S x≢ _) Z          =  ⊥-elim (x≢ refl)
-∋-injective (S _ ∋x) (S _ ∋x′)  =  ∋-injective ∋x ∋x′
+∋-functional : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
+∋-functional Z        Z          =  refl
+∋-functional Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
+∋-functional (S x≢ _) Z          =  ⊥-elim (x≢ refl)
+∋-functional (S _ ∋x) (S _ ∋x′)  =  ∋-functional ∋x ∋x′
 ```
 
-The typing relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`
+The typing relation `Γ ⊢ M ⦂ A` is not functional. For example, in any `Γ`
 the term `` ƛ "x" ⇒ ` "x" `` has type `A ⇒ A` for any type `A`.
 
 ### Non-examples
@@ -1370,7 +1370,7 @@ doing so requires types `A` and `B` such that `A ⇒ B ≡ A`:
 
 ```
 nope₂ : ∀ {A} → ¬ (∅ ⊢ ƛ "x" ⇒ ` "x" · ` "x" ⦂ A)
-nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-injective ∋x ∋x′)
+nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-functional ∋x ∋x′)
   where
   contradiction : ∀ {A B} → ¬ (A ⇒ B ≡ A)
   contradiction ()

--- a/extra/Frames/Lambda.lagda.md
+++ b/extra/Frames/Lambda.lagda.md
@@ -1336,19 +1336,19 @@ Chapter [Inference](/Inference/)
 will show how to use Agda to compute type derivations directly.
 
 
-### Lookup is injective
+### Lookup is functional
 
-The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
+The lookup relation `Γ ∋ x ⦂ A` is functional, in that for each `Γ` and `x`
 there is at most one `A` such that the judgment holds:
 ```
-∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
-∋-injective Z        Z          =  refl
-∋-injective Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
-∋-injective (S x≢ _) Z          =  ⊥-elim (x≢ refl)
-∋-injective (S _ ∋x) (S _ ∋x′)  =  ∋-injective ∋x ∋x′
+∋-functional : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
+∋-functional Z        Z          =  refl
+∋-functional Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
+∋-functional (S x≢ _) Z          =  ⊥-elim (x≢ refl)
+∋-functional (S _ ∋x) (S _ ∋x′)  =  ∋-functional ∋x ∋x′
 ```
 
-The typing relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`
+The typing relation `Γ ⊢ M ⦂ A` is not functional. For example, in any `Γ`
 the term `` ƛ "x" ⇒ ` "x" `` has type `A ⇒ A` for any type `A`.
 
 ### Non-examples
@@ -1370,7 +1370,7 @@ doing so requires types `A` and `B` such that `A ⇒ B ≡ A`:
 
 ```
 nope₂ : ∀ {A} → ¬ (∅ ⊢ ƛ "x" ⇒ ` "x" · ` "x" ⦂ A)
-nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-injective ∋x ∋x′)
+nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-functional ∋x ∋x′)
   where
   contradiction : ∀ {A B} → ¬ (A ⇒ B ≡ A)
   contradiction ()

--- a/extra/extra/Lambda-new.lagda
+++ b/extra/extra/Lambda-new.lagda
@@ -1199,19 +1199,19 @@ Chapter [Inference]({{ site.baseurl }}{% link out/plta/DeBruijn.md %})
 will show how to use Agda to compute type derivations directly.
 
 
-### Lookup is injective
+### Lookup is functional
 
-The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
+The lookup relation `Γ ∋ x ⦂ A` is functional, in that for each `Γ` and `x`
 there is at most one `A` such that the judgment holds.
 \begin{code}
-∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
-∋-injective Z        Z          =  refl
-∋-injective Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
-∋-injective (S x≢ _) Z          =  ⊥-elim (x≢ refl)
-∋-injective (S _ ∋x) (S _ ∋x′)  =  ∋-injective ∋x ∋x′
+∋-functional : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
+∋-functional Z        Z          =  refl
+∋-functional Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
+∋-functional (S x≢ _) Z          =  ⊥-elim (x≢ refl)
+∋-functional (S _ ∋x) (S _ ∋x′)  =  ∋-functional ∋x ∋x′
 \end{code}
 
-The typing relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`
+The typing relation `Γ ⊢ M ⦂ A` is not functional. For example, in any `Γ`
 the term `ƛ "x" ⇒ "x"` has type `A ⇒ A` for any type `A`.
 
 ### Non-examples
@@ -1233,7 +1233,7 @@ doing so requires types `A` and `B` such that `A ⇒ B ≡ A`.
 
 \begin{code}
 nope₂ : ∀ {A} → ¬ (∅ ⊢ ƛ "x" ⇒ ` "x" · ` "x" ⦂ A)
-nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-injective ∋x ∋x′)
+nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-functional ∋x ∋x′)
   where
   contradiction : ∀ {A B} → ¬ (A ⇒ B ≡ A)
   contradiction ()

--- a/extra/stlc/StlcNew.lagda
+++ b/extra/stlc/StlcNew.lagda
@@ -841,16 +841,16 @@ The entire process can be automated using Agsy, invoked with C-c C-a.
 
 ### Injective
 
-Note that `Γ ∋ x ⦂ A` is injective.
+Note that `Γ ∋ x ⦂ A` is functional.
 \begin{code}
-∋-injective : ∀ {Γ w A B} → Γ ∋ w ⦂ A → Γ ∋ w ⦂ B → A ≡ B
-∋-injective Z        Z          =  refl
-∋-injective Z        (S w≢ _)   =  ⊥-elim (w≢ refl)
-∋-injective (S w≢ _) Z          =  ⊥-elim (w≢ refl)
-∋-injective (S _ ∋w) (S _ ∋w′)  =  ∋-injective ∋w ∋w′
+∋-functional : ∀ {Γ w A B} → Γ ∋ w ⦂ A → Γ ∋ w ⦂ B → A ≡ B
+∋-functional Z        Z          =  refl
+∋-functional Z        (S w≢ _)   =  ⊥-elim (w≢ refl)
+∋-functional (S w≢ _) Z          =  ⊥-elim (w≢ refl)
+∋-functional (S _ ∋w) (S _ ∋w′)  =  ∋-functional ∋w ∋w′
 \end{code}
 
-The relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`
+The relation `Γ ⊢ M ⦂ A` is not functional. For example, in any `Γ`
 the term `ƛ "x" ⇒ "x"` has type `A ⇒ A` for any type `A`.
 
 ### Non-examples
@@ -875,7 +875,7 @@ contradiction : ∀ {A B} → ¬ (A ⇒ B ≡ A)
 contradiction ()
 
 ex₂ : ∀ {A} → ¬ (∅ ⊢ ƛ "x" ⇒ # "x" · # "x" ⦂ A)
-ex₂ (⇒-I (⇒-E (Ax ∋x) (Ax ∋x′)))  =  contradiction (∋-injective ∋x ∋x′)
+ex₂ (⇒-I (⇒-E (Ax ∋x) (Ax ∋x′)))  =  contradiction (∋-functional ∋x ∋x′)
 \end{code}
 
 

--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -1331,19 +1331,19 @@ Chapter [Inference](/Inference/)
 will show how to use Agda to compute type derivations directly.
 
 
-### Lookup is injective
+### Lookup is functional
 
-The lookup relation `Γ ∋ x ⦂ A` is injective, in that for each `Γ` and `x`
+The lookup relation `Γ ∋ x ⦂ A` is functional, in that for each `Γ` and `x`
 there is at most one `A` such that the judgment holds:
 ```
-∋-injective : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
-∋-injective Z        Z          =  refl
-∋-injective Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
-∋-injective (S x≢ _) Z          =  ⊥-elim (x≢ refl)
-∋-injective (S _ ∋x) (S _ ∋x′)  =  ∋-injective ∋x ∋x′
+∋-functional : ∀ {Γ x A B} → Γ ∋ x ⦂ A → Γ ∋ x ⦂ B → A ≡ B
+∋-functional Z        Z          =  refl
+∋-functional Z        (S x≢ _)   =  ⊥-elim (x≢ refl)
+∋-functional (S x≢ _) Z          =  ⊥-elim (x≢ refl)
+∋-functional (S _ ∋x) (S _ ∋x′)  =  ∋-functional ∋x ∋x′
 ```
 
-The typing relation `Γ ⊢ M ⦂ A` is not injective. For example, in any `Γ`
+The typing relation `Γ ⊢ M ⦂ A` is not functional. For example, in any `Γ`
 the term `` ƛ "x" ⇒ ` "x" `` has type `A ⇒ A` for any type `A`.
 
 ### Non-examples
@@ -1365,7 +1365,7 @@ doing so requires types `A` and `B` such that `A ⇒ B ≡ A`:
 
 ```
 nope₂ : ∀ {A} → ¬ (∅ ⊢ ƛ "x" ⇒ ` "x" · ` "x" ⦂ A)
-nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-injective ∋x ∋x′)
+nope₂ (⊢ƛ (⊢` ∋x · ⊢` ∋x′))  =  contradiction (∋-functional ∋x ∋x′)
   where
   contradiction : ∀ {A B} → ¬ (A ⇒ B ≡ A)
   contradiction ()


### PR DESCRIPTION
Personally I feel `lookup` is more like a function from variables to types, and "injectivity" is functionality from this point of view. I forgot to say on the mailing list that this change was originally suggested by my (anonymous) student.