### PR TITLE
Fix bulleted list for isomorphism record explanation

### DIFF
--- a/src/plfa/part1/Isomorphism.lagda.md
+++ b/src/plfa/part1/Isomorphism.lagda.md
@@ -160,10 +160,11 @@ open _≃_
 ```
 Let's unpack the definition. An isomorphism between sets `A` and `B` consists
 of four things:
-+ A function `to` from `A` to `B`,
-+ A function `from` from `B` back to `A`,
-+ Evidence `from∘to` asserting that `from` is a *left-inverse* for `to`,
-+ Evidence `to∘from` asserting that `from` is a *right-inverse* for `to`.
+
+  1. A function `to` from `A` to `B`,
+  2. A function `from` from `B` back to `A`,
+  3. Evidence `from∘to` asserting that `from` is a *left-inverse* for `to`,
+  4. Evidence `to∘from` asserting that `from` is a *right-inverse* for `to`.
 
 In particular, the third asserts that `from ∘ to` is the identity, and
 the fourth that `to ∘ from` is the identity, hence the names.


### PR DESCRIPTION
Minor text change

The bulleted list for explaining the [isomorphism record](https://plfa.inf.ed.ac.uk/Isomorphism/#isomorphism) is broken for me. It looks like this:

![image](https://user-images.githubusercontent.com/22649160/147719764-c0c8169b-8450-420f-977c-06c6a9bbd7b9.png)

This PR changes it to look like this:

![image](https://user-images.githubusercontent.com/22649160/147719773-00a7b53d-958c-4ce7-9130-570af7ff20d2.png)

I went with a numbered list since items are referred to as the 'third' and 'fourth'.