### PR TITLE
remove paragraph that duplicates what's in the exercises

### DIFF
--- a/src/plfa/part1/Relations.lagda.md
+++ b/src/plfa/part1/Relations.lagda.md
@@ -592,11 +592,6 @@ requires negation, as does the fact that the three cases in
 trichotomy are mutually exclusive, so those points are deferred to
 Chapter [Negation](/Negation/).
 
-It is straightforward to show that `suc m ≤ n` implies `m < n`,
-and conversely.  One can then give an alternative derivation of the
-properties of strict inequality, such as transitivity, by
-exploiting the corresponding properties of inequality.
-
 #### Exercise `<-trans` (recommended) {#less-trans}
 
 Show that strict inequality is transitive.


### PR DESCRIPTION
The presence of this paragraph here suggests that this approach should
be used for <-trans.  So that's what I did.  But then when I read
further I saw that this content/paragraph is duplicated in the ≤-iff-< and
<-trans-revisited exercises, and actually this approach is intended
for those exercises.  So I was a bit confused.

I don't know what the appropriate wording/ordering is here, but I
think just deleting this paragraph would be reasonable since the
content is duplicated in the ≤-iff-< and <-trans-revisited exercises.