### PR TITLE
lists: move postulate of foldr-++ up to the exercise, add missing "code goes here"

### DIFF
--- a/src/plfa/part1/Lists.lagda.md
+++ b/src/plfa/part1/Lists.lagda.md
@@ -353,6 +353,9 @@ reverse of the second appended to the reverse of the first:
 
     reverse (xs ++ ys) ≡ reverse ys ++ reverse xs
 
+```
+-- Your code goes here
+```
 
 #### Exercise `reverse-involutive` (recommended)
 
@@ -361,6 +364,9 @@ as the identity function.  Show that reverse is an involution:
 
     reverse (reverse xs) ≡ xs
 
+```
+-- Your code goes here
+```
 
 ## Faster reverse
 
@@ -718,6 +724,9 @@ equal to `n * (n ∸ 1) / 2`:
 
     sum (downFrom n) * 2 ≡ n * (n ∸ 1)
 
+```
+-- Your code goes here
+```
 
 ## Monoids
 

--- a/src/plfa/part1/Lists.lagda.md
+++ b/src/plfa/part1/Lists.lagda.md
@@ -644,7 +644,11 @@ For example:
 
 Show that fold and append are related as follows:
 
+```
+postulate
+  foldr-++ : ∀ {A B : Set} (_⊗_ : A → B → B) (e : B) (xs ys : List A) →
     foldr _⊗_ e (xs ++ ys) ≡ foldr _⊗_ (foldr _⊗_ e ys) xs
+```
 
 ```
 -- Your code goes here
@@ -789,12 +793,8 @@ foldr-monoid _⊗_ e ⊗-monoid (x ∷ xs) y =
   ∎
 ```
 
-In a previous exercise we showed the following.
-```
-postulate
-  foldr-++ : ∀ {A : Set} (_⊗_ : A → A → A) (e : A) (xs ys : List A) →
-    foldr _⊗_ e (xs ++ ys) ≡ foldr _⊗_ (foldr _⊗_ e ys) xs
-```
+In the foldr-++ exercise we showed
+foldr _⊗_ e (xs ++ ys) ≡ foldr _⊗_ (foldr _⊗_ e ys) xs
 
 As a consequence, using a previous exercise, we have the following:
 ```


### PR DESCRIPTION
This follows the pattern set by the previous chapters, which always
postulate things proved by exercises and needed by later proofs, in
the exercise itself.  It's also slightly more convenient when doing the
exercise - one can just remove the "postulate" as a purely local
change, rather than having to scroll down and delete the postulate
from where it's used later.

Plus, the postulate of foldr-++ before took a _⊗_ : A → A → A, which
is insufficiently general for all the exercises, namely foldr-∷.

Just something I ran into, feel free to reject!