### PR TITLE
Fix some broken links in Lambda sections

### DIFF
--- a/src/plfa/part2/Lambda.lagda.md
+++ b/src/plfa/part2/Lambda.lagda.md
@@ -236,8 +236,8 @@ case′ L [zero⇒ M |suc (` x) ⇒ N ]  =  case L [zero⇒ M |suc x ⇒ N ]
 
 Recall that `T` is a function that maps from the computation world to
 the evidence world, as
-[defined]({{ site.baseurl }}/Decidable/#relating-evidence-and-computation)
-in Chapter [Decidable]({{ site.baseurl }}/Decidable/).  We ensure to
+[defined](/Decidable/#relating-evidence-and-computation)
+in Chapter [Decidable](/Decidable/).  We ensure to
 use the primed functions only when the respective term argument is a
 variable, which we do by providing implicit evidence.  For example, if
 we tried to define an abstraction term that binds anything but a


### PR DESCRIPTION
Hyperlinks to the `Decidable` chapters are broken, found in
https://github.com/Agda-zh/PLFA-zh/runs/5684809207?check_suite_focus=true#step:9:72
