### PR TITLE
WIP: upgrade to GHC-8.10.7, drop pandoc-citeproc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,8 +20,8 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v2
       with:
-        ref: dev
-        fetch-depth: 1
+        # ref: dev
+        # fetch-depth: 1
         submodules: true
 
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,6 @@ jobs:
         fetch-depth: 1
         submodules: true
 
-    - name: Update stack.yaml
-      run: |
-        stack config set system-ghc true
-        stack config set install-ghc false
-      shell: bash
-
 
     # Setup & Cache Haskell
 
@@ -50,7 +44,36 @@ jobs:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: 'latest'
         stack-version: 'latest'
+      id: haskell-setup
 
+    - name: Update stack.yaml
+      run: |
+        stack config set system-ghc true
+        stack config set install-ghc false
+      shell: bash
+
+    - name: Info about the setup
+      shell: bash
+      run: |
+        echo "runner.os   = ${{ runner.os }}"
+        echo "ghc-path    = ${{ steps.haskell-setup.outputs.ghc-path    }}"
+        echo "cabal-path  = ${{ steps.haskell-setup.outputs.cabal-path  }}"
+        echo "stack-path  = ${{ steps.haskell-setup.outputs.stack-path  }}"
+        echo "cabal-store = ${{ steps.haskell-setup.outputs.cabal-store }}"
+        echo "ghc-exe     = ${{ steps.haskell-setup.outputs.ghc-exe     }}"
+        echo "cabal-exe   = ${{ steps.haskell-setup.outputs.cabal-exe   }}"
+        echo "stack-exe   = ${{ steps.haskell-setup.outputs.stack-exe   }}"
+        echo "stack-root  = ${{ steps.haskell-setup.outputs.stack-root  }}"
+        echo "STACK_VER=$(stack --numeric-version)" >> ${GITHUB_ENV}
+        echo "GHC_VER=$(ghc --numeric-version)" >> ${GITHUB_ENV}
+
+    - name: Haskell versions
+      shell: bash
+      run: |
+        echo "GHC_VER     = ${{ env.GHC_VER   }}"
+        echo "STACK_VER   = ${{ env.STACK_VER }}"
+        # echo "STACK_YAML=stack-${{ env.GHC_VER }}.yaml" >> ${GITHUB_ENV}
+        # echo "STACK_FLAGS=--stack-yaml stack-${{ env.GHC_VER }}.yaml --system-ghc --no-terminal --color always" >> ${GITHUB_ENV}
 
     # Setup & Cache HTMLProofer
 
@@ -92,7 +115,7 @@ jobs:
 
     - name: Build Pandoc
       if: steps.cache-site-builder.outputs.cache-hit != 'true'
-      run: stack build pandoc-2.10.1
+      run: stack build pandoc-2.18
       shell: bash
 
     - name: Build other dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macOS-latest]
+        os: [ubuntu-latest]
+        # [macOS-latest]
         ghc: ['8.10.7']
         agda: ['2.6.1.3']
 
@@ -98,6 +99,13 @@ jobs:
       shell: bash
 
 
+    - name: Prepare Agda standard library
+      run: |
+        cabal update
+        cd standard-library
+        cabal run --allow-newer GenerateEverything
+        cd ..
+      shell: bash
 
     # Setup & Cache Agda, pandoc, and site builder
 
@@ -111,14 +119,20 @@ jobs:
     - name: Update stack
       run: stack update --silent
 
-    - name: Build Pandoc
-      if: steps.cache-site-builder.outputs.cache-hit != 'true'
-      run: stack build pandoc
-      shell: bash
-
     - name: Build Agda
       if: steps.cache-site-builder.outputs.cache-hit != 'true'
       run: stack build Agda-${{ matrix.agda }}
+      shell: bash
+
+    # To avoid locked .agdai files when building the site,
+    # we precompile the .agdai files of the standard library.
+    - name: Build standard-library
+      run: stack exec --cwd standard-library agda -- -i . -i src Everything.agda
+      shell: bash
+
+    - name: Build Pandoc
+      if: steps.cache-site-builder.outputs.cache-hit != 'true'
+      run: stack build pandoc
       shell: bash
 
     - name: Build other dependencies

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [macOS-latest]
-        ghc: ['8.10.5']
+        ghc: ['8.10.7']
         agda: ['2.6.1.3']
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -98,15 +98,6 @@ jobs:
       run: sudo gem install html-proofer
       shell: bash
 
-
-    - name: Prepare Agda standard library
-      run: |
-        cabal update
-        cd standard-library
-        cabal run --allow-newer GenerateEverything
-        cd ..
-      shell: bash
-
     # Setup & Cache Agda, pandoc, and site builder
 
     - name: Cache .stack-work
@@ -124,11 +115,19 @@ jobs:
       run: stack build Agda-${{ matrix.agda }}
       shell: bash
 
-    # To avoid locked .agdai files when building the site,
-    # we precompile the .agdai files of the standard library.
-    - name: Build standard-library
-      run: stack exec --cwd standard-library agda -- -i . -i src Everything.agda
-      shell: bash
+    # - name: Prepare Agda standard library
+    #   run: |
+    #     cabal update
+    #     cd standard-library
+    #     cabal run --allow-newer GenerateEverything
+    #     cd ..
+    #   shell: bash
+
+    # # To avoid locked .agdai files when building the site,
+    # # we precompile the .agdai files of the standard library.
+    # - name: Build standard-library
+    #   run: stack exec --cwd standard-library agda -- -i . -i src Everything.agda
+    #   shell: bash
 
     - name: Build Pandoc
       if: steps.cache-site-builder.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,14 +108,17 @@ jobs:
         path: $GITHUB_WORKSPACE/.stack-work
         key: ${{ matrix.os }}-ghc-${{ matrix.ghc }}-agda-${{ matrix.agda }}
 
-    - name: Build Agda
-      if: steps.cache-site-builder.outputs.cache-hit != 'true'
-      run: stack build Agda-${{ matrix.agda }}
-      shell: bash
+    - name: Update stack
+      run: stack update --silent
 
     - name: Build Pandoc
       if: steps.cache-site-builder.outputs.cache-hit != 'true'
-      run: stack build pandoc-2.18
+      run: stack build pandoc
+      shell: bash
+
+    - name: Build Agda
+      if: steps.cache-site-builder.outputs.cache-hit != 'true'
+      run: stack build Agda-${{ matrix.agda }}
       shell: bash
 
     - name: Build other dependencies

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ RAW_DIR   := $(SITE_DIR)/raw
 CACHE_DIR := _cache
 TMP_DIR   := $(CACHE_DIR)/tmp
 
+AGDA_BIN  := $(STACK) exec agda --
 AGDA      := $(STACK) exec agda -- --no-libraries --include-path=standard-library/src
 PANDOC    := $(STACK) exec pandoc --
 
@@ -52,6 +53,7 @@ build-deps:
 .PHONY: build
 build: standard-library/ChangeLog.md | build-deps
 	@echo "Building website"
+	src/typecheck-plfa.sh "$(AGDA_BIN)"
 	$(STACK) build
 	$(STACK) exec site build
 

--- a/plfa.cabal
+++ b/plfa.cabal
@@ -22,10 +22,12 @@ common shared-properties
                   , filemanip            >=0.3   && <0.4
                   , filepath             >=1.3   && <1.5
                   , frontmatter          >=0.1   && <0.2
-                  , hakyll               >=4.10  && <4.15
-                  , pandoc               >=2.1   && <2.11
+                  , hakyll               >=4.10
+                      -- && <4.15
+                  , pandoc               >=2.1
+                      -- && <2.11
                   , pandoc-types         >=1.20  && <1.23
-                  , pandoc-citeproc      >=0.17  && <0.18
+                  -- , pandoc-citeproc      >=0.17  && <0.18
                   , text                 >=1.2   && <1.3
                   , text-icu             >=0.7.1 && <0.8
                   , text-regex-replace   >=0.1   && <0.2
@@ -57,5 +59,5 @@ executable update-contributors
   import:           shared-properties
   main-is:          hs/UpdateContributors.hs
   build-depends:    exceptions         >=0.10 && <0.11
-                  , github             >=0.26 && <0.27
+                  , github             >=0.27 && <0.29
                   , vector             >=0.12 && <0.13

--- a/src/typecheck-plfa.sh
+++ b/src/typecheck-plfa.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+# Script to build the PFLA sources with agda.
+# Andreas Abel, 2022-05-30
+
+# Run this script from the project root.
+# It expects the name of the agda binary as first argument (defaults to agda-2.6.1.3).
+AGDA_BIN=${1:-agda-2.6.1.3}
+
+# Generate libraries file
+echo "standard-library/standard-library.agda-lib" > libraries
+
+AGDA="${AGDA_BIN} --library-file=libraries"
+
+# Check all files that define BUILTINs
+for f in $(grep -r --include=\*.lagda.md -e BUILTIN -l src); do
+  echo ${AGDA} $f;
+  ${AGDA} $f;
+done
+
+# Collect all files that do not define BUILTINs
+EVERYTHING=src/Everything.agda
+cat > ${EVERYTHING} <<EOF
+-- List of all agda files that do not define a BUILTIN.
+-- Automatically generated, DO NOT EDIT!
+
+module Everything where
+
+EOF
+grep -r --include=\*.lagda.md -e BUILTIN -L src | sed -e 's/src\//import /g' | sed -e 's/\.lagda\.md//g' | sed -e 's/\//\./g' >> ${EVERYTHING}
+
+# Check those in one go
+echo ${AGDA} ${EVERYTHING}
+${AGDA} ${EVERYTHING}
+
+# Done!

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,9 +1,9 @@
-resolver: lts-17.2
+resolver: lts-18.28
 
-compiler: ghc-8.10.5
+compiler: ghc-8.10.7
 compiler-check: match-exact
 
-allow-newer: true
+# allow-newer: true
 
 flags:
   pandoc:
@@ -13,16 +13,23 @@ packages:
 - .
 
 extra-deps:
-- Agda-2.6.1.3@sha256:87769ebab4259b184c5b11d5beaff39b88bcc37902dfb3341f4fc46c5c7d3134,32945
-- hakyll-4.13.4.1
-- pandoc-2.10.1@sha256:23d7ec480c7cb86740475a419d6ca4819987b6dd23bbae9b50bc3d42a7ed2f9f,36933
-- pandoc-citeproc-0.17.0.2@sha256:39c5c60a5eca2c1cb50ae9a00dc7093ca1baac78ad5be4e222505de257dce456,8737
-- commonmark-0.1.1.4@sha256:8717891c53c124ff64187c463619450241a41c0951cda2a43267d40f78992362,3278
-- commonmark-extensions-0.2.0.4@sha256:6a437bcfa3c757af4262b71336513619990eafb5cfdc33e57a499c93ad225608,3184
-- commonmark-pandoc-0.2.0.1@sha256:529c6e2c6cabf61558b66a28123eafc1d90d3324be29819f59f024e430312c1f,1105
-- hsass-0.8.0@sha256:05fb3d435dbdf9f66a98db4e1ee57a313170a677e52ab3a5a05ced1fc42b0834,2899
-- hlibsass-0.1.10.1@sha256:08db56c633e9a83a642d8ea57dffa93112b092d05bf8f3b07491cfee9ee0dfa5,2565
-- github-0.26@sha256:a9d4046325c3eb28cdc7bef2c3f5bb213328caeae0b7dce6f51de655f0bffaa1,7162
-- binary-instances-1.0.0.1@sha256:e234be994da675479a3661f050d4a1d53565c9ed7786d9a68b7a29ba8b54b5a7,2659
-- text-regex-replace-0.1.1.3@sha256:e7f612df671c93ced54a3d26528db37852069884e5cb67d5afbb49d3defb5eb9,1627
-- text-icu-0.7.1.0@sha256:44e8b5966fcf61356a7356f3d2e8a5c5cc538170a15e94ff7b79b9f48ce9fd2f,3497
+- Agda-2.6.1.3
+- github-0.28
+- hakyll-4.15.1.1
+# - hakyll-4.14.1.0
+# - pandoc-citeproc-0.17.0.2
+
+
+# - Agda-2.6.1.3@sha256:87769ebab4259b184c5b11d5beaff39b88bcc37902dfb3341f4fc46c5c7d3134,329# 45
+# - hakyll-4.13.4.1
+# - pandoc-2.10.1@sha256:23d7ec480c7cb86740475a419d6ca4819987b6dd23bbae9b50bc3d42a7ed2f9f,36933
+# - pandoc-citeproc-0.17.0.2@sha256:39c5c60a5eca2c1cb50ae9a00dc7093ca1baac78ad5be4e222505de257dce456,8737
+# - commonmark-0.1.1.4@sha256:8717891c53c124ff64187c463619450241a41c0951cda2a43267d40f78992362,3278
+# - commonmark-extensions-0.2.0.4@sha256:6a437bcfa3c757af4262b71336513619990eafb5cfdc33e57a499c93ad225608,3184
+# - commonmark-pandoc-0.2.0.1@sha256:529c6e2c6cabf61558b66a28123eafc1d90d3324be29819f59f024e430312c1f,1105
+# - hsass-0.8.0@sha256:05fb3d435dbdf9f66a98db4e1ee57a313170a677e52ab3a5a05ced1fc42b0834,2899
+# - hlibsass-0.1.10.1@sha256:08db56c633e9a83a642d8ea57dffa93112b092d05bf8f3b07491cfee9ee0dfa5,2565
+# - github-0.26@sha256:a9d4046325c3eb28cdc7bef2c3f5bb213328caeae0b7dce6f51de655f0bffaa1,7162
+# - binary-instances-1.0.0.1@sha256:e234be994da675479a3661f050d4a1d53565c9ed7786d9a68b7a29ba8b54b5a7,2659
+# - text-regex-replace-0.1.1.3@sha256:e7f612df671c93ced54a3d26528db37852069884e5cb67d5afbb49d3defb5eb9,1627
+# - text-icu-0.7.1.0@sha256:44e8b5966fcf61356a7356f3d2e8a5c5cc538170a15e94ff7b79b9f48ce9fd2f,3497


### PR DESCRIPTION
Fixes #649 (CI).

CI currently looks very sad.  It basically never ran successfully.

This PR gets CI into a working state by:
- Upgrading from GHC 8.10.5 to 8.10.7 and the latest stack LTS 18.28 for GHC 8.10
- Dropping deprecated `pandoc-citeproc`, allowing newer `pandoc`
- Skipping the `processCites` step in page building until solution independent of `pandoc-citeproc` is available
- Pre-building the Agda standard library, fixing races in the site building process (locked `.agdai` files)
- Not fixing the CI branch to `dev`, allowing it to run on PRs like this one.
  (So, you may not see CI running on this PR before it has been merged into `dev`.)

In the current state (2022-05-21), CI succeeds (see https://github.com/andreasabel/plfa.github.io/actions/runs/2364301888), but there are the following loose ends / TODOs left:
- [ ] Clean up, comment on the decisions
- [ ] Extend CI to other platforms (Windows(?), add back macOS)
- [ ] Cache cabal directory
- [ ] Maybe cache Agda standard-library
- [ ] ~~Build Agda faster by turning off aggressive optimization~~ [EDIT: not easy; flag `optimise-heavily` was only introduced in Agda 2.6.2] (this would be obsolete by switching to Agda-2.6.2 which has it off by default)
- [ ] Migrate the processing of citations
- [x] Fix races in site building (ADDED after CI run)
  These might be fixed in the newer builders (shake/shoggoth)!?

Ad "migrating `processCites`":
- Atm, there are only two references for self-citations, thus, I decided skipping these would not be terrible: https://github.com/plfa/plfa.github.io/blob/a798dc6a76ced81fc3fbb869861d010423e30ccb/bib/plfa.bib
- I asked for migration help upstream: 
  * https://github.com/jgm/pandoc/issues/8081

Ad "races" (ADDED):
CI still experiences races (https://github.com/plfa/plfa.github.io/runs/6543439794?check_suite_focus=true#step:19:443) which I tried to circumvent by pre-building the Agda standard library:
```
/home/runner/work/plfa.github.io/plfa.github.io/src/plfa/part3/Soundness.lagda.md:50,1-63
/home/runner/work/plfa.github.io/plfa.github.io/_build/2.6.1.3/agda/src/plfa/part2/Substitution.agdai:
openBinaryFile: resource busy (file is locked)
```

Let me know what you think / how to proceed from here.

I suggest to finally squash the commits.

