### PR TITLE
Fix module headers in part2.fixpoint-old.*

### DIFF
--- a/src/plfa/part2/fixpoint-old/LambdaFixpoint.lagda.md
+++ b/src/plfa/part2/fixpoint-old/LambdaFixpoint.lagda.md
@@ -7,7 +7,7 @@ next      : /Properties/
 ---
 
 ```
-module plfa.part2.LambdaFixpoint where
+module plfa.part2.fixpoint-old.LambdaFixpoint where
 ```
 
 The _lambda-calculus_, first published by the logician Alonzo Church in
@@ -490,7 +490,7 @@ _[_:=_] : Term → Id → Term → Term
 (case L [zero⇒ M |suc x ⇒ N ]) [ y := V ] with x ≟ y
 ... | yes _          =  case L [ y := V ] [zero⇒ M [ y := V ] |suc x ⇒ N ]
 ... | no  _          =  case L [ y := V ] [zero⇒ M [ y := V ] |suc x ⇒ N [ y := V ] ]
-(μ f ⇒ ƛ x ⇒ N) [ y := V ] with f ≟ y | x ≟ y 
+(μ f ⇒ ƛ x ⇒ N) [ y := V ] with f ≟ y | x ≟ y
 ... | yes _ | _      =  μ f ⇒ ƛ x ⇒ N
 ... | no  _ | yes _  =  μ f ⇒ ƛ x ⇒ N
 ... | no  _ | no  _  =  μ f ⇒ ƛ x ⇒ N [ y := V ]

--- a/src/plfa/part2/fixpoint-old/PropertiesFixpoint.lagda.md
+++ b/src/plfa/part2/fixpoint-old/PropertiesFixpoint.lagda.md
@@ -7,7 +7,7 @@ next      : /DeBruijn/
 ---
 
 ```
-module plfa.part2.PropertiesFixpoint where
+module plfa.part2.fixpoint-old.PropertiesFixpoint where
 ```
 
 This chapter covers properties of the simply-typed lambda calculus, as
@@ -32,7 +32,7 @@ open import Data.Sum using (_⊎_; inj₁; inj₂)
 open import Relation.Nullary using (¬_; Dec; yes; no)
 open import Function using (_∘_)
 open import plfa.part1.Isomorphism
-open import plfa.part2.LambdaFixpoint
+open import plfa.part2.fixpoint-old.LambdaFixpoint
 ```
 
 
@@ -523,7 +523,7 @@ contradiction (evidenced by `x≢x refl`).
 
 Third, if the last two variables in a context differ then we can swap them:
 ```
-swap-ρ : ∀ {Γ x y A B} 
+swap-ρ : ∀ {Γ x y A B}
   → x ≢ y
     --------------------------------------
   → Γ , y ⦂ B , x ⦂ A →ᴿ Γ , x ⦂ A , y ⦂ B


### PR DESCRIPTION
See 
- https://github.com/plfa/plfa.github.io/pull/652#issuecomment-1143553143

Agda files saved to `fixpoint-old/` are missing `.fixpoint-old` as part of their module name.  Fixed here.

Please merge via "Merge commit" (not squash or rebase).