### PR TITLE
Remove a problematic link

### DIFF
--- a/web/TableOfContents.md
+++ b/web/TableOfContents.md
@@ -55,7 +55,7 @@ $endfor$
   * [Jeremy Siek, Indiana University][IU-2020]
   * [Maria Emilia Maietti and Ingo Blechschmidt, Università di Padova][Padova-2020]
   * [John Maraist, University of Wisconsin-La Crosse][UWL-2020]
-  * [Ugo de'Liguoro, Università di Torino][Torino-2020]
+  * Ugo de'Liguoro, Università di Torino
 
 #### 2019
   * [Dan Ghica, University of Birmingham][BHAM-2019]


### PR DESCRIPTION
The link destination was removed in commit
265a7143 (Add contributor instructions, 2022-06-22)
presumably due to the destination URL being dead.

However, the markdown link was not removed at the same time.