### PR TITLE
First argument to +-assoc here should be (m + n) rather than just n.

### DIFF
--- a/src/plfa/part1/Induction.lagda.md
+++ b/src/plfa/part1/Induction.lagda.md
@@ -623,7 +623,7 @@ Proposition `+-assoc (m + n) p q` shifts parentheses from left to right:
 
     ((m + n) + p) + q ≡ (m + n) + (p + q)
 
-To shift them the other way, we use `sym (+-assoc n p q)`:
+To shift them the other way, we use `sym (+-assoc (m + n) p q)`:
 
     (m + n) + (p + q) ≡ ((m + n) + p) + q
 


### PR DESCRIPTION
The text is describing the Agda code for the associativity of addition over the variables `(m + n)`, `p` and `q`. However, in this line, unlike the code it is describing, `n` is used by mistake instead of `(m + n)`.