### PR TITLE
fix code block delimiter in Soundness

### DIFF
--- a/src/plfa/part3/Soundness.lagda.md
+++ b/src/plfa/part3/Soundness.lagda.md
@@ -526,7 +526,7 @@ subst-reflect (sub d lt) eq
     From the later we have `(δ , v₁) ⊢ # 0 ↓ v′`.
     By the lemma `var-inv` we have `v′ ⊑ v₁`, so by the `up-env` lemma we
     have `(δ′ , v₁) ⊢ M′ ↓ v₂` and therefore `δ′ ⊢ ƛ M′ ↓ v₁ → v₂`.  We
-    also need to show that `δ `⊢ σ ↓ δ′`.  Fix `k`. We have
+    also need to show that `δ ⊢ σ ↓ δ′`.  Fix `k`. We have
     `(δ , v₁) ⊢ rename S_ σ k ↓ δ k′`.  We then apply the lemma
     `rename-inc-reflect` to obtain `δ ⊢ σ k ↓ δ k′`, so this case is
     complete.


### PR DESCRIPTION
Fixes a minor issue where an inline code block is closed before intended, causing the some of the code to be outside of a code block and some of the prose to be inside of a code block.