### PR TITLE
Minor Fix: Remove Wrong `suc` in Explanation on Existential Quantifier Example

### DIFF
--- a/src/plfa/part1/Quantifiers.lagda.md
+++ b/src/plfa/part1/Quantifiers.lagda.md
@@ -333,7 +333,7 @@ substituting for `n`.
 
 * If the number is odd because it is the successor of an even number,
 then we apply the induction hypothesis to give a number `m` and
-evidence that `m * 2 ≡ n`. We return a pair consisting of `suc m` and
+evidence that `m * 2 ≡ n`. We return a pair consisting of `m` and
 evidence that `1 + m * 2 ≡ suc n`, which is immediate after
 substituting for `n`.
 


### PR DESCRIPTION
Hello there,

In the chapter on quantifiers, in the subsection "_An existential example_", in the explanation of the third case of the proof of `odd-∃`, it is written:

    We return a pair consisting of `suc m` and evidence that `1 + m * 2 ≡ suc n`, which is immediate after substituting for `n`,

while actually `m` and not `suc m` is returned as the first element in the pair.