### PR TITLE
Update Agda version in README to 2.6.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,9 @@ jobs:
 
       - name: Set standard-library version
         if: matrix.agda-stdlib-version != '1.7.2'
-        run: git checkout v${{ matrix.agda-stdlib-version }}
+        run: |
+          git fetch origin v${{ matrix.agda-stdlib-version }}:v${{ matrix.agda-stdlib-version }} --depth=1
+          git checkout v${{ matrix.agda-stdlib-version }}
         working-directory: standard-library
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,8 +51,7 @@ jobs:
             agda-version: "2.6.2"
             ghc-version: "9.2.4"
             experimental: true
-          # Newer versions of Agda
-          - name: Build with newer Agda 2.6.3
+          - name: Build with newer Agda 2.6.2.2
             os: ubuntu-latest
             agda-version: "2.6.3"
             ghc-version: "9.2.4"
@@ -60,18 +59,18 @@ jobs:
           # Older versions of GHC
           - name: Build with older GHC 8.10.7
             os: ubuntu-latest
-            agda-version: "2.6.2.2"
+            agda-version: "2.6.3"
             ghc-version: "8.10.7"
             experimental: false
           - name: Build with older GHC 9.0.2
             os: ubuntu-latest
-            agda-version: "2.6.2.2"
+            agda-version: "2.6.3"
             ghc-version: "9.0.2"
             experimental: false
           # Newer versions of GHC
           - name: Build with newer GHC 9.4.4
             os: ubuntu-latest
-            agda-version: "2.6.2.2"
+            agda-version: "2.6.3"
             ghc-version: "9.4.4"
             experimental: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,49 +28,58 @@ jobs:
           - name: Build on macOS
             os: macOS-latest
             agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
             ghc-version: "9.2.4"
             experimental: false
           - name: Build on Linux
             os: ubuntu-latest
             agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
             ghc-version: "9.2.4"
             experimental: false
           - name: Build on Windows
             os: windows-latest
             agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
             ghc-version: "9.2.4"
             experimental: false
           # Older versions of Agda
           - name: Build with older Agda 2.6.2.1
             os: ubuntu-latest
             agda-version: "2.6.2.1"
+            agda-stdlib-version: "1.7.1"
             ghc-version: "9.2.4"
             experimental: true
           - name: Build with older Agda 2.6.2
             os: ubuntu-latest
             agda-version: "2.6.2"
+            agda-stdlib-version: "1.7.1"
             ghc-version: "9.2.4"
             experimental: true
           - name: Build with older Agda 2.6.2.2
             os: ubuntu-latest
             agda-version: "2.6.2.2"
+            agda-stdlib-version: "1.7.1"
             ghc-version: "9.2.4"
             experimental: true
           # Older versions of GHC
           - name: Build with older GHC 8.10.7
             os: ubuntu-latest
             agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
             ghc-version: "8.10.7"
             experimental: false
           - name: Build with older GHC 9.0.2
             os: ubuntu-latest
             agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
             ghc-version: "9.0.2"
             experimental: false
           # Newer versions of GHC
           - name: Build with newer GHC 9.4.4
             os: ubuntu-latest
             agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
             ghc-version: "9.4.4"
             experimental: true
 
@@ -117,6 +126,11 @@ jobs:
         with:
           path: _cache
           key: build-${{ runner.os }}-${{ secrets.BUILD_CACHE_VERSION }}
+
+      - name: Update standard library
+        if: matrix.agda-stdlib-version != '1.7.2'
+        run: git checkout v${{ matrix.agda-stdlib-version }}
+        working-directory: standard-library
 
       - name: Build
         run: make build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,17 +27,17 @@ jobs:
           # Recommended versions
           - name: Build on macOS
             os: macOS-latest
-            agda-version: "2.6.2.2"
+            agda-version: "2.6.3"
             ghc-version: "9.2.4"
             experimental: false
           - name: Build on Linux
             os: ubuntu-latest
-            agda-version: "2.6.2.2"
+            agda-version: "2.6.3"
             ghc-version: "9.2.4"
             experimental: false
           - name: Build on Windows
             os: windows-latest
-            agda-version: "2.6.2.2"
+            agda-version: "2.6.3"
             ghc-version: "9.2.4"
             experimental: false
           # Older versions of Agda

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,12 @@ jobs:
             ghc-version: "9.2.4"
             experimental: false
           # Older versions of Agda
+          - name: Build with older Agda 2.6.2.2
+            os: ubuntu-latest
+            agda-version: "2.6.2.2"
+            agda-stdlib-version: "1.7.1"
+            ghc-version: "9.2.4"
+            experimental: true
           - name: Build with older Agda 2.6.2.1
             os: ubuntu-latest
             agda-version: "2.6.2.1"
@@ -53,12 +59,6 @@ jobs:
           - name: Build with older Agda 2.6.2
             os: ubuntu-latest
             agda-version: "2.6.2"
-            agda-stdlib-version: "1.7.1"
-            ghc-version: "9.2.4"
-            experimental: true
-          - name: Build with older Agda 2.6.2.2
-            os: ubuntu-latest
-            agda-version: "2.6.2.2"
             agda-stdlib-version: "1.7.1"
             ghc-version: "9.2.4"
             experimental: true
@@ -127,7 +127,7 @@ jobs:
           path: _cache
           key: build-${{ runner.os }}-${{ secrets.BUILD_CACHE_VERSION }}
 
-      - name: Update standard library
+      - name: Set standard-library version
         if: matrix.agda-stdlib-version != '1.7.2'
         run: git checkout v${{ matrix.agda-stdlib-version }}
         working-directory: standard-library

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,9 @@ jobs:
             agda-version: "2.6.2"
             ghc-version: "9.2.4"
             experimental: true
-          - name: Build with newer Agda 2.6.2.2
+          - name: Build with older Agda 2.6.2.2
             os: ubuntu-latest
-            agda-version: "2.6.3"
+            agda-version: "2.6.2.2"
             ghc-version: "9.2.4"
             experimental: true
           # Older versions of GHC

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,19 +62,6 @@ jobs:
             agda-stdlib-version: "1.7.1"
             ghc-version: "9.2.4"
             experimental: true
-          # Older versions of GHC
-          - name: Build with older GHC 8.10.7
-            os: ubuntu-latest
-            agda-version: "2.6.3"
-            agda-stdlib-version: "1.7.2"
-            ghc-version: "8.10.7"
-            experimental: false
-          - name: Build with older GHC 9.0.2
-            os: ubuntu-latest
-            agda-version: "2.6.3"
-            agda-stdlib-version: "1.7.2"
-            ghc-version: "9.0.2"
-            experimental: false
           # Newer versions of GHC
           - name: Build with newer GHC 9.4.4
             os: ubuntu-latest
@@ -82,6 +69,19 @@ jobs:
             agda-stdlib-version: "1.7.2"
             ghc-version: "9.4.4"
             experimental: true
+          # Older versions of GHC
+          - name: Build with older GHC 9.0.2
+            os: ubuntu-latest
+            agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
+            ghc-version: "9.0.2"
+            experimental: false
+          - name: Build with older GHC 8.10.7
+            os: ubuntu-latest
+            agda-version: "2.6.3"
+            agda-stdlib-version: "1.7.2"
+            ghc-version: "8.10.7"
+            experimental: false
 
     name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The easiest way to install Agda is using Cabal. PLFA uses Agda version 2.6.2.2. 
 
 ```bash
 cabal update
-cabal install Agda-2.6.2.2
+cabal install Agda-2.6.3
 ```
 
 This step will take a long time and a lot of memory to complete.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ or using `ghcup tui` and choosing to `set` the appropriate tools.
 
 ### Install Agda
 
-The easiest way to install Agda is using Cabal. PLFA uses Agda version 2.6.2.2. Run the following command:
+The easiest way to install Agda is using Cabal. PLFA uses Agda version 2.6.3. Run the following command:
 
 ```bash
 cabal update
@@ -262,22 +262,22 @@ If you plan to build PLFA locally, please refer to [Contributing][plfa-contribut
 [plfa-badge-version-url]: https://github.com/plfa/plfa.github.io/releases/latest
 [plfa-badge-status-svg]: https://github.com/plfa/plfa.github.io/actions/workflows/build.yml/badge.svg
 [plfa-badge-status-url]: https://github.com/plfa/plfa.github.io/actions/workflows/build.yml
-[agda-badge-version-svg]: https://img.shields.io/badge/agda-v2.6.2.2-blue.svg
-[agda-badge-version-url]: https://github.com/agda/agda/releases/tag/v2.6.2.2
-[agda-stdlib-version-svg]: https://img.shields.io/badge/agda--stdlib-v1.7.1-blue.svg
-[agda-stdlib-version-url]: https://github.com/agda/agda-stdlib/releases/tag/v1.7.1
+[agda-badge-version-svg]: https://img.shields.io/badge/agda-v2.6.3-blue.svg
+[agda-badge-version-url]: https://github.com/agda/agda/releases/tag/v2.6.3.
+[agda-stdlib-version-svg]: https://img.shields.io/badge/agda--stdlib-v1.7.2-blue.svg
+[agda-stdlib-version-url]: https://github.com/agda/agda-stdlib/releases/tag/v1.7.2
 [plfa]: https://plfa.inf.ed.ac.uk
 [plfa-epub]: https://plfa.github.io/plfa.epub
 [plfa-contributing]: https://plfa.github.io/Contributing/
 [ghcup]: https://www.haskell.org/ghcup/
 [git]: https://git-scm.com/downloads
 [xcode]: https://developer.apple.com/xcode/
-[agda-readthedocs-installation]: https://agda.readthedocs.io/en/v2.6.2.2/getting-started/installation.html
-[agda-readthedocs-hello-world]: https://agda.readthedocs.io/en/v2.6.2.2/getting-started/hello-world.html
-[agda-readthedocs-holes]: https://agda.readthedocs.io/en/v2.6.2.2/getting-started/a-taste-of-agda.html#preliminaries
-[agda-readthedocs-emacs-mode]: https://agda.readthedocs.io/en/v2.6.2.2/tools/emacs-mode.html
-[agda-readthedocs-emacs-notation]: https://agda.readthedocs.io/en/v2.6.2.2/tools/emacs-mode.html#notation-for-key-combinations
-[agda-readthedocs-package-system]: https://agda.readthedocs.io/en/v2.6.2.2/tools/package-system.html#example-using-the-standard-library
+[agda-readthedocs-installation]: https://agda.readthedocs.io/en/v2.6.3/getting-started/installation.html
+[agda-readthedocs-hello-world]: https://agda.readthedocs.io/en/v2.6.3/getting-started/hello-world.html
+[agda-readthedocs-holes]: https://agda.readthedocs.io/en/v2.6.3/getting-started/a-taste-of-agda.html#preliminaries
+[agda-readthedocs-emacs-mode]: https://agda.readthedocs.io/en/v2.6.3/tools/emacs-mode.html
+[agda-readthedocs-emacs-notation]: https://agda.readthedocs.io/en/v2.6.3/tools/emacs-mode.html#notation-for-key-combinations
+[agda-readthedocs-package-system]: https://agda.readthedocs.io/en/v2.6.3/tools/package-system.html#example-using-the-standard-library
 [emacs]: https://www.gnu.org/software/emacs/download.html
 [emacs-tour]: https://www.gnu.org/software/emacs/tour/
 [emacs-home]: https://www.gnu.org/software/emacs/manual/html_node/efaq-w32/Location-of-init-file.html

--- a/courses/TSPL/2022/Instructions.tex
+++ b/courses/TSPL/2022/Instructions.tex
@@ -36,7 +36,7 @@
   You are permitted to use your browser to access the following:
   \begin{quote}
     \url{plfa.inf.ed.ac.uk} -- the course textbook \\
-    \url{agda.readthedocs.io/en/v2.6.2.2/} -- the Agda user manual
+    \url{agda.readthedocs.io/en/v2.6.3/} -- the Agda user manual
   \end{quote}
   You are also permitted to bring in two sides of A4 printed notes,
   covering whatever you find helpful. These may be inspected by the

--- a/web/posts/2023-02-26-migration-to-agda-2.6.3.md
+++ b/web/posts/2023-02-26-migration-to-agda-2.6.3.md
@@ -1,0 +1,10 @@
+---
+title: "Migration to Agda 2.6.3"
+---
+
+We upgraded to [Agda 2.6.3][agda-2.6.3] and [version 1.7.2 of the standard library][agda-stdlib-v1.7.2]. If you want to continue working with the book, you'll have to update your versions locally. Please follow the instructions in [Getting Started](/GettingStarted/) to reinstall Agda and the standard library.
+
+[agda-stdlib-v1.7.2]: https://github.com/agda/agda-stdlib/releases/tag/v1.7.2
+  "Agda standard library version 1.7.2 on GitHub"
+[agda-2.6.3]: https://github.com/agda/agda/releases/tag/v2.6.3
+  "Agda version 2.6.3 on GitHub"


### PR DESCRIPTION
Current instructions may result in an 'agda-mode compile' build error. Updating the version resolves the issue.