### PR TITLE
Reasoning and Example on Modelling Predicates as Inductive Data Types in Chapter `Equality` (#760)

### DIFF
--- a/src/plfa/part1/Equality.lagda.md
+++ b/src/plfa/part1/Equality.lagda.md
@@ -171,7 +171,12 @@ subst : ∀ {A : Set} {x y : A} (P : A → Set)
   → P x → P y
 subst P refl px = px
 ```
-
+A predicate is a proposition over values of some type `A`, and since we model
+_propositions as types_, a predicate is a type parameterized in `A`.
+As an example, consider our earlier examples `even` and `odd` from
+Chapter [Relations](/Relations/#even-and-odd), which are predicates on natural numbers `ℕ`.
+(We will compare representing predicates as inductive data types `A → Set`
+versus functions to booleans `A → Bool` in Chapter [Decidable](/Decidable/).)
 
 ## Chains of equations
 

--- a/src/plfa/part1/Relations.lagda.md
+++ b/src/plfa/part1/Relations.lagda.md
@@ -649,7 +649,7 @@ the fact that inequality is transitive.
 ```
 
 
-## Even and odd
+## Even and odd {#even-and-odd}
 
 As a further example, let's specify even and odd numbers.  Inequality
 and strict inequality are _binary relations_, while even and odd are

--- a/src/plfa/part1/Relations.lagda.md
+++ b/src/plfa/part1/Relations.lagda.md
@@ -649,7 +649,7 @@ the fact that inequality is transitive.
 ```
 
 
-## Even and odd {#even-and-odd}
+## Even and odd
 
 As a further example, let's specify even and odd numbers.  Inequality
 and strict inequality are _binary relations_, while even and odd are


### PR DESCRIPTION
Closes #760 .

Following suggestions in the discussion on issue #760, this pull request adds
- some reasoning on why predicates are modelled as parameterized types `A → Set`,
- a pointer to earlier examples `even` and `odd`,
- and a pointer to the future discussion on modelling predicates as types `A → Set` versus functions `A → Bool` in Chapter Decidable

at the first explicit occurence of generic predicates as paramaters in Chapter `Equality`.

I am happy to receive any feedback. 😃 (I had some trouble setting up ruby to test the new links, so they are yet untested; but I formatted them according to existing links in the book.)

Kind regards,
Paul