### PR TITLE
Import ⇔ in connectives for Exercise ⇔≃×

### DIFF
--- a/src/plfa/part1/Connectives.lagda.md
+++ b/src/plfa/part1/Connectives.lagda.md
@@ -32,7 +32,7 @@ open Eq using (_≡_; refl)
 open Eq.≡-Reasoning
 open import Data.Nat using (ℕ)
 open import Function using (_∘_)
-open import plfa.part1.Isomorphism using (_≃_; _≲_; extensionality)
+open import plfa.part1.Isomorphism using (_≃_; _≲_; extensionality; _⇔_)
 open plfa.part1.Isomorphism.≃-Reasoning
 ```
 


### PR DESCRIPTION
This import was missing for the exercises in this chapter. In particular the ⇔≃× exercise needs this imported.