### PR TITLE
Little typo Connectives.lagda.md

### DIFF
--- a/src/plfa/part1/Connectives.lagda.md
+++ b/src/plfa/part1/Connectives.lagda.md
@@ -123,7 +123,7 @@ term `⟨ M , N ⟩` where `M` is a term of type `A` and `N` is a term of type `
 The constructor declaration allows us to write `⟨ M , N ⟩′` in place of the
 record construction.
 
-The data type `_x_` and the record type `_×′_` behave similarly. One
+The data type `_×_` and the record type `_×′_` behave similarly. One
 difference is that for data types we have to prove η-equality, but for record
 types, η-equality holds *by definition*. While proving `η-×′`, we do not have to
 pattern match on `w` to know that η-equality holds:


### PR DESCRIPTION
Replaced \_x\_ by \_×\_ in the Connectives.lagda.md file.