### PR TITLE
Change recommended ghc 9.2.4 -> 9.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ If you do not have Git, see [the Git downloads page][git].
 Agda is written in Haskell, so to install it we’ll need the _Glorious Haskell Compiler_ and its package manager _Cabal_. PLFA should work with any version of GHC >=8.10, but is tested with versions 8.10 and 9.2. We recommend installing GHC and Cabal using [ghcup][ghcup].  For instance, once `ghcup` is installed, by typing
 
 ```bash
-ghcup install ghc 9.2.4
+ghcup install ghc 9.2.8
 ghcup install cabal recommended
 
-ghcup set ghc 9.2.4
+ghcup set ghc 9.2.8
 ghcup set cabal recommended
 ```
 or using `ghcup tui` and choosing to `set` the appropriate tools.


### PR DESCRIPTION
As described in the changelog for ghc 9.2.5 https://downloads.haskell.org/~ghc/9.2.5/docs/html/users_guide/9.2.5-notes.html, there's an issue with segfaults on macOS 13+ https://gitlab.haskell.org/ghc/ghc/-/issues/21964

Have confirmed that 9.2.4 crashes on my M1 mac with OSX Sonoma, but when I used 9.2.8 instead it worked.