### PR TITLE
add option to `git clone` to prevent issue with recursive submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ If you'd like, you can [test to see if you've installed Agda correctly][agda-rea
 We recommend installing PLFA from Github into your home directory, by running the following command:
 
 ```bash
-git clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/plfa/plfa.github.io plfa
+git -c protocol.file.allow=always clone --depth 1 --recurse-submodules --shallow-submodules https://github.com/plfa/plfa.github.io plfa
 ```
 
 PLFA ships with the required version of the Agda standard library, so if you cloned with the `--recurse-submodules` flag, you’ve already got it, in the `standard-library` directory!


### PR DESCRIPTION
A recent vulnerability fix prevents `git clone` from working with git version 2.39.2.  This patch opens the vulnerability for the clone command only, meaning that the user is trusting the plfa repo.

Details at https://stackoverflow.com/questions/74486167/git-clone-recurse-submodules-throws-error-on-macos-transmission-type-file-n