### PR TITLE
Add warning about `C-space` on Mac

### DIFF
--- a/src/plfa/part1/Naturals.lagda.md
+++ b/src/plfa/part1/Naturals.lagda.md
@@ -838,6 +838,9 @@ filled, you can type `C-c C-space`, which will remove the hole:
     zero + n = n
     suc m + n = { }1
 
+Note: `C-space` may be a reserved command on Mac OS X, in which case
+try typing `C-c C-r` instead.
+
 Again, going into hole 1 and typing `C-c C-,` will display information on the
 required type of the hole, and what free variables are available:
 


### PR DESCRIPTION
Modern OS X seems to reserve `C-space` for toggling keyboard encodings. The VS Code plugin suggests `C-c C-r` as usually a reasonable replacement for `C-c C-space`, so I've suggested adding the same tip. I don't know enough about `C-c C-r` to know whether this is dangerous advice or needs more expansion, or whether it's worth trying to understand how to override the system's control of `C-space` entirely.