### PR TITLE
Compact definition of ¬¬¬-elim

### DIFF
--- a/src/plfa/part1/Negation.lagda.md
+++ b/src/plfa/part1/Negation.lagda.md
@@ -99,7 +99,7 @@ We cannot show that `¬ ¬ A` implies `A`, but we can show that
   → ¬ ¬ ¬ A
     -------
   → ¬ A
-¬¬¬-elim ¬¬¬x  =  λ x → ¬¬¬x (¬¬-intro x)
+¬¬¬-elim ¬¬¬x x  =  ¬¬¬x (¬¬-intro x)
 ```
 Let `¬¬¬x` be evidence of `¬ ¬ ¬ A`. We will show that assuming
 `A` leads to a contradiction, and hence `¬ A` must hold.


### PR DESCRIPTION
> We will usually use this latter style, as it is more compact.

Consistent with the style mentioned to be preferred in [¬¬-intro′](https://plfa.github.io/Negation/#plfa_plfa-part1-Negation-2556) 