### PR TITLE
Switch trans' from quote to prime in text to match agda code

### DIFF
--- a/src/plfa/part1/Equality.lagda.md
+++ b/src/plfa/part1/Equality.lagda.md
@@ -285,7 +285,7 @@ if it improves readability!)
 
 #### Exercise `trans` and `≡-Reasoning` (practice)
 
-Sadly, we cannot use the definition of `trans'` using ≡-Reasoning as the
+Sadly, we cannot use the definition of `trans′` using ≡-Reasoning as the
 definition for trans. Can you see why? (Hint: look at the definition
 of `_≡⟨_⟩_`)
 


### PR DESCRIPTION
Just another tiny edit.  Reading the text I searched for `trans'` to refer to it, but got no results and thought at first the definition was missing.  Actually, the definition uses the prime character whereas the name in the text used a single quote.

This makes the name in the agda code reflexively equal to the name in the text :)