### PR TITLE
TableOfContents.md: mention PLFArend as a Derived work

### DIFF
--- a/web/TableOfContents.md
+++ b/web/TableOfContents.md
@@ -112,6 +112,10 @@ $endfor$
 [TSPL-2018]: https://plfa.github.io/19.08/TSPL/2018/
 [UVM-2018]: https://web.archive.org/web/20190324115921/https://david.darais.com/courses/fa2018-cs295A/
 
+### Derived works
+
+* [PLFArend](https://github.com/marat-rkh/PLFArend): the PLFA book with all code snippets rewritten in Arend.
+
 Please tell us of others!
 
 [GitHub]: https://github.com/plfa/plfa.github.io/


### PR DESCRIPTION
Hello! I have been working on rewriting the PLFA in Arend. @wadler suggested mentioning it as a derived work, thank you for this opportunity!
https://agda.zulipchat.com/#narrow/channel/238741-general
I have added the attribution to the README.md of my project as required by the CC-BY-4.0. Once again, sorry for not doing it in the first place. No bad intentions, I just considered this work to be a personal project that very few people would be interested in.
Also, I have exacted my work to a separate repo (thanks for the PLFArend name idea!). This way it is clearly separated from the original book.