### PR TITLE
TableOfContents.md: mention `rami3l/PLFaLean` as a derived work

### DIFF
--- a/web/TableOfContents.md
+++ b/web/TableOfContents.md
@@ -115,6 +115,7 @@ $endfor$
 ### Derived works
 
 * [PLFArend](https://github.com/marat-rkh/PLFArend): the PLFA book with all code snippets rewritten in Arend.
+* [PLFaLean](https://github.com/rami3l/PLFaLean): PLFA proofs implemented in Lean 4, covering Parts 2-3 of the v22.08 release of the book.
 
 Please tell us of others!
 


### PR DESCRIPTION
Closes https://github.com/rami3l/plfl/issues/15.

As proposed in that very issue, this PR adds `rami3l/PLFaLean` as a derived work of PLFA.

@wadler Many thanks again for your appreciation!