### PR TITLE
Update email address for Jeremy G. Siek

### DIFF
--- a/data/authors/3-siek.yml
+++ b/data/authors/3-siek.yml
@@ -1,4 +1,4 @@
 name: Jeremy G. Siek
-email: jsiek@indiana.edu
+email: jsiek@iu.edu
 corresponding: true
 github: jsiek


### PR DESCRIPTION
Changed indiana to iu. (IU's marketing team thought that was a good idea. Joy.)